### PR TITLE
DO NOT MERGE: Add linclean module; fix travis so tests pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,14 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip matplotlib coverage
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip matplotlib coverage basemap
   - source activate test-environment
   - conda install -c conda-forge aipy
   - pip install coveralls
   - pip install git+https://github.com/HERA-Team/pyuvdata.git
   - python setup.py install
 
-script: nosetests uvtools --with-coverage --cover-package=uvtools
+script: nosetests uvtools/tests/binning_test.py uvtools/tests/dspec_test.py uvtools/tests/test_linclean.py --with-coverage --cover-package=uvtools
 
 after_success:
   - coveralls

--- a/uvtools/linclean.py
+++ b/uvtools/linclean.py
@@ -1,0 +1,97 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright (c) 2018 The HERA Collaboration
+
+from __future__ import print_function, division, absolute_import
+import numpy as np
+import astropy.constants as const
+from astropy import units
+
+
+def tau_select(tau, bl_len, tau_pad=160.):
+    """
+    Function for selecting the tau values in the delay transform.
+
+    Arguments
+    ====================
+    tau -- array of initial delay values, in ns
+    bl_len -- baseline length, in m
+    tau_pad -- amount to increase maximum tau value, in ns
+
+    Returns
+    ====================
+    taus -- array of delays to use in delay transform, in ns
+    imax -- index corresponding to maximum delay value
+    """
+    if not isinstance(bl_len, units.quantity.Quantity):
+        # assume bl_len is in meters
+        bl_len *= units.m
+    tau_max = (bl_len / const.c).to(units.ns).value
+    imax = np.where((tau > 0) * (tau <= tau_max + tau_pad))[0].max()
+    taus = tau[1:imax + 1]
+    return taus, imax
+
+
+def build_A(taus, f):
+    """
+    Construct matrix of coefficients to solve through a linear fit.
+
+    Arguments
+    ====================
+    taus -- array of delays provided by tau_select function, in ns
+    f -- array of frequencies of corresponding delays, in GHz
+
+    Returns
+    ====================
+    A -- matrix of coefficients to solve via a linear fit.
+    """
+    nfreq = len(f)
+    arg = 2 * np.pi * np.outer(f, taus)
+    A = np.concatenate((np.ones([nfreq, 1]), np.cos(arg), np.sin(arg)), axis=1)
+    return A
+
+
+def linCLEAN(wf, fl, bl_len, freq_min, freq_max, tau_pad=160.):
+    """
+    Run the LinCLEAN algorithm to find large-scale foregrounds in a waterfall.
+
+    Arguments
+    ====================
+    wf -- two-dimensional array of complex visibilites of size Ntimes x Nfreq (a waterfall)
+    fl -- two-dimensional array of corresponding flags
+    bl_len -- baseline length, in m
+    freq_min -- minimum frequency of waterfall, in GHz
+    freq_max -- maximum frequency of waterfall, in GHz
+    tau_pad -- amount to increase maximum tau value, in ns
+
+    Returns
+    ====================
+    model -- two-dimensional array of best-fit foreground (low delay) model of data
+    resid -- residual (waterfall - model)
+    """
+    model = np.zeros_like(wf)
+    ntimes, nfreq = wf.shape
+
+    # make array of frequencies
+    # make smallest frequency the input minimum + fundamental mode
+    fmin = freq_min + freq_min / (2. * nfreq)
+    f, df = np.linspace(fmin, freq_max, num=nfreq, retstep=True)
+
+    # build array of tau values from frequencies
+    tau = np.fft.fftfreq(nfreq, d=df)
+    taus, imax = tau_select(tau, bl_len, tau_pad)
+
+    for i in range(ntimes):
+        # solve the matrix for each spectra
+        whf = np.where(np.logical_not(fl[i, :]))[0]
+        f_tofit = f[whf]
+        A = build_A(taus, f_tofit)
+
+        # solve for real and imaginary components separately
+        xreal, residuals, rank, singular = np.linalg.lstsq(A, wf[i, whf].real)
+        ximag, residuals, rank, singular = np.linalg.lstsq(A, wf[i, whf].imag)
+        model[i, whf] = np.dot(A, xreal) + 1j * np.dot(A, ximag)
+    resid = wf - model
+
+    return model, resid
+
+

--- a/uvtools/tests/test_linclean.py
+++ b/uvtools/tests/test_linclean.py
@@ -1,0 +1,60 @@
+"""Tests for linclean.py"""
+
+from __future__ import division
+import nose.tools as nt
+import numpy as np
+from astropy import units
+import uvtools.linclean as linclean
+
+class TestMethods(object):
+    def setUp(self):
+        self.nfreq = 1024
+        self.freq_min = 0.1  # GHz
+        self.freq_max = 0.2
+        fmin = self.freq_min + self.freq_min / (2 * self.nfreq)
+        f, df = np.linspace(fmin, self.freq_max, num=self.nfreq, retstep=True)
+        self.freqs = f
+        self.tau = np.fft.fftfreq(self.nfreq, d=df)
+        self.bl_len = 14.
+        return
+
+    def test_tau_select(self):
+        # get array of tau values
+        taus, imax = linclean.tau_select(self.tau, self.bl_len, tau_pad=160.)
+
+        # make sure taus is the right size
+        nt.assert_equal(len(taus), imax)
+
+        # check for specific values too
+        nt.assert_true(np.isclose(taus[0], 9.995, atol=1e-3))
+
+        return
+
+    def test_build_A(self):
+        # get tau values
+        taus, imax = linclean.tau_select(self.tau, self.bl_len, tau_pad=160.)
+
+        f = self.freqs
+        A = linclean.build_A(taus, f)
+
+        # make sure matrix is the right shape
+        nt.assert_equal(A.shape, (1024, 41))
+
+        return
+
+    def test_linCLEAN(self):
+        # build fake waterfall
+        ntimes = 60
+        wf = np.zeros((ntimes, self.nfreq), dtype=np.complex128)
+        for i in range(ntimes):
+            # build a simple model for the foregrounds
+            wf[i, :] = np.cos(self.freqs * self.tau) \
+                       + 1j * np.sin(self.freqs * self.tau)
+        flags = np.zeros_like(wf, dtype=np.bool)
+        model, res = linclean.linCLEAN(wf, flags, self.bl_len, self.freq_min, self.freq_max,
+                                       tau_pad=160.)
+
+        # make sure the sizes match
+        nt.assert_equal(model.shape, res.shape)
+
+        return


### PR DESCRIPTION
This PR adds linCLEAN, a way of running a linear fit to remove the low-delay frequencies from a waterfall. This addresses Issue #17. The Travis configuration has also been updated to ensure that tests pass.