### PR TITLE
added frf.py and FRFilter class with tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
   - pip install git+https://github.com/HERA-Team/omnical.git
   - pip install git+https://github.com/HERA-Team/linsolve.git
   - pip install git+https://github.com/HERA-Team/hera_qm.git
+  - pip install git+https://github.com/HERA-Team/uvtools.git
   - pip install git+https://github.com/HERA-Team/hera_cal.git
   - pip install healpy
   - pip install scikit-learn

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,14 @@ install:
   - conda install -c conda-forge aipy
   - pip install coveralls
   - pip install git+https://github.com/HERA-Team/pyuvdata.git
+  - pip install git+https://github.com/HERA-Team/omnical.git
+  - pip install git+https://github.com/HERA-Team/linsolve.git
+  - pip install git+https://github.com/HERA-Team/hera_qm.git
+  - pip install git+https://github.com/HERA-Team/hera_cal.git
+  - pip install healpy
+  - pip install scikit-learn
+  - pip install h5py
+  - pip install pyyaml
   - python setup.py install
 
 script: nosetests uvtools/tests/test_dspec.py --with-coverage --cover-package=uvtools

--- a/uvtools/__init__.py
+++ b/uvtools/__init__.py
@@ -4,6 +4,8 @@ import binning
 import plot
 import notebook
 import version
+import frf
+from frf import FRFilter 
 
 __version__ = version.version
 

--- a/uvtools/frf.py
+++ b/uvtools/frf.py
@@ -1,0 +1,354 @@
+import numpy as np
+import hera_cal as hc
+from pyuvdata import UVData
+import pyuvdata.utils as uvutils
+from collections import OrderedDict as odict
+import copy
+import os
+
+
+def timeavg_waterfall(data, Navg, flags=None, nsamples=None, rephase=False, lsts=None, 
+                      freqs=None, bl_vec=None, lat=-30.72152, extra_arrays={}, verbose=True):
+    """
+    Calculate the time average of a visibility waterfall. The average is optionally
+    weighted by a boolean flag array (flags) and also optionally by an Nsample array (nsample),
+    such that, for a single frequency channel, the time average is constructed as
+
+    avg_data = sum( data * flag_wgt * nsample ) / sum( flag_wgt * nsample )
+
+    where flag_wgt is constructed as (~flags).astype(np.float).
+
+    Additionally, one can rephase each integration in the averaging window to the LST of the
+    window-center before taking their average. This assumes the
+    input data are drift-scan phased. See hera_cal.utils.lst_rephase 
+    for details on the rephasing algorithm. By feeding an nsample array,
+    one can also construct the averaged nsample for each averaging window.
+
+    Parameters
+    ----------
+    data : ndarray
+        2D complex ndarray of complex visibility with shape=(Ntimes, Nfreqs)
+        The rows of data are assumed to be ordered chronologically, in either 
+        asending or descending order.
+
+    Navg : int
+        Number of time samples to average together, with the condition
+        that 0 < Navg <= Ntimes. Navg = 1 is no averaging. Navg = Ntimes
+        is complete averaging.
+
+    flags : ndarray
+        2D boolean ndarray containing data flags with matching shape of data.
+        Flagged pixels are True, otherwise False.
+
+    nsamples : ndarray, optional
+        2D float ndarray containing the number of pre-averages behind each pixel
+        in data. Default is to assume unity for all pixels.
+
+    rephase : boolean, optional
+        if True, shift the phase center of each integration to the
+        LST of the averaging window-center before averaging. Need to
+        feed lsts, freqs and bl_vec if True.
+
+    lsts : ndarray, optional
+        1D float array holding the LST [radians] of each time integration in 
+        data. Shape=(Ntimes,)
+
+    freqs : ndarray, optional
+        1D float array holding the starting frequency of each frequency bin [Hz]
+        in data. Shape=(Nfreqs,)
+
+    bl_vec : ndarray, optional
+        3D float ndarray containing baseline vector of visibility in meters
+        in the ENU (TOPO) frame.
+
+    lat : float, optional
+        Latitude of observer in degrees North. Default is HERA coordinates.
+
+    extra_arrays : dict, optional
+        Dictionary of extra 1D arrays with shape=(Ntimes,) to push through
+        averaging windows.
+    
+    verbose : bool, optional
+        if True, report feedback to standard output.
+
+    Returns
+    -------
+    avg_data : ndarray
+        2D complex array with time-average spectrum, shape=(Navg_times, Nfreqs)
+
+    win_flags : ndarray
+        2D boolean array with OR of flags in averaging window, shape=(Navg_times, Nfreqs)
+
+    avg_nsamples : ndarray
+        2D array containing the sum of nsamples of each averaging window, weighted
+        by the input flags, if fed. Shape=(Navg_times, Nfreqs)
+
+    avg_lsts : ndarray
+        1D float array holding the center LST of each averaging window, if
+        lsts was fed. Shape=(Navg_times,).
+
+    avg_extra_arrays : dict
+        Dictionary of 1D arrays holding average of input extra_arrays for
+        each averaging window, shape=(Navg_times,).
+    """
+    # type check
+    assert isinstance(data, np.ndarray), "data must be fed as an ndarray"
+    if rephase:
+        assert lsts is not None and freqs is not None and bl_vec is not None, "" \
+               "If rephase is True, must feed lsts and freqs"
+
+    # unwrap lsts if fed
+    if lsts is not None:
+        lsts = np.unwrap(lsts)
+
+    # form flags if None
+    if flags is None:
+        flags = np.zeros_like(data, dtype=np.bool)
+    assert isinstance(flags, np.ndarray), "flags must be fed as an ndarray"
+
+    # turn flags into weights
+    flagw = (~flags).astype(np.float)
+
+    # form nsamples if None
+    if nsamples is None:
+        nsamples = np.ones_like(data, dtype=np.float)
+    assert isinstance(nsamples, np.ndarray), "nsamples must be fed as an ndarray"
+
+    # assert Navg makes sense
+    Ntimes = data.shape[0]
+    assert Navg <= Ntimes and Navg > 0, "Navg must satisfy 0 < Navg <= Ntimes"
+
+    # calculate Navg_times, the number of remaining time samples after averaging
+    Navg_times = float(Ntimes) / Navg
+    if Navg_times % 1 > 1e-10:
+        if verbose: print "Warning: Ntimes is not evenly divisible by Navg, " \
+                          "meaning the last output time sample will be noisier "\
+                          "than the others."
+    Navg_times = int(np.ceil(Navg_times))
+
+    # form output avg list
+    avg_data = []
+    win_flags = []
+    avg_lsts = []
+    avg_nsamples = []
+    avg_extra_arrays = dict([('avg_{}'.format(a), []) for a in extra_arrays])
+
+    # iterate through Navg_times
+    for i in range(Navg_times):
+        # get starting and stopping indices
+        start = i * Navg
+        end = (i + 1) * Navg
+        d = data[start:end, :]
+        f = flags[start:end, :]
+        fw = flagw[start:end, :]
+        n = nsamples[start:end, :]
+
+        # calculate mean_l and l, if lsts was fed
+        if lsts is not None:
+            l = lsts[start:end]
+            mean_l = np.mean(l)
+            avg_lsts.append(mean_l)
+
+        # rephase data if desired
+        if rephase:
+            # get dlst and rephase
+            dlst = mean_l - l
+            d = hc.utils.lst_rephase(d, bl_vec, freqs, dlst, lat=lat, inplace=False, array=True)
+
+        w = fw * n
+        w_sum = np.sum(w, axis=0, keepdims=False).clip(1e-10, np.inf)
+
+        ad = np.sum(d * w, keepdims=False, axis=0) / w_sum
+        an = np.sum(w, keepdims=False, axis=0)
+
+        avg_data.append(ad)
+        win_flags.append(np.min(f, axis=0, keepdims=False))
+        avg_nsamples.append(an)
+
+        # average arrays in extra_arrays
+        for a in extra_arrays:
+            avg_extra_arrays['avg_{}'.format(a)].append(np.mean(extra_arrays[a][start:end]))
+
+    avg_data = np.array(avg_data, np.complex)
+    win_flags = np.array(win_flags, np.bool)
+    avg_nsamples = np.array(avg_nsamples, np.float)
+    avg_lsts = np.array(avg_lsts, np.float)
+
+    # wrap lsts
+    avg_lsts = avg_lsts % (2*np.pi)
+
+    return avg_data, win_flags, avg_nsamples, avg_lsts, avg_extra_arrays
+
+
+class FRFilter(object):
+    """
+    Fringe Rate Filter
+    """
+    def __init__(self):
+        """
+        Fringe Rate Filter
+        """
+        pass
+
+    def load_data(self, inp_data, filetype='miriad'):
+        """
+        Load in visibility data for filtering
+
+        Parameters
+        ----------
+        inp_data : UVData or str
+            UVData object or string filepath to visibility data
+
+        filetype : str
+            File format of the data. Only miriad is currently supported.
+        """
+        assert isinstance(inp_data, (UVData, str, np.str)), "inp_data must be fed as a UVData object or a string filepath"
+
+        # load uvdata if fed as string
+        if isinstance(inp_data, (str, np.str)):
+            ### TODO: Change to using hc.io.file_to_uvd
+            self.inp_uvdata = UVData()
+            self.inp_uvdata.read_miriad(inp_data)
+        else:
+            self.inp_uvdata = inp_data
+
+        self.filetype = filetype
+
+        (self.data, self.flags, self.antpos, self.ants, self.freqs, self.times, self.lsts, 
+         self.pols) = hc.io.load_vis(self.inp_uvdata, return_meta=True, filetype=filetype)
+        self.nsamples = odict([(k, self.inp_uvdata.get_nsamples(k)) for k in self.data.keys()])
+        self.nsamples = hc.datacontainer.DataContainer(self.nsamples)
+        self.Nfreqs = len(self.freqs)
+        self.Ntimes = len(self.times)
+        self.dlst = np.median(np.diff(self.lsts))
+        self.dtime = np.median(np.diff(self.times))
+        self.bls = sorted(set([k[:2] for k in self.data.keys()]))
+        self.blvecs = odict([(bl, self.antpos[bl[0]] - self.antpos[bl[1]]) for bl in self.bls])
+        self.lat = self.inp_uvdata.telescope_location_lat_lon_alt[0] * 180 / np.pi
+
+    def timeavg_data(self, t_avg, rephase=False, verbose=True):
+        """
+        Time average data attached to object given a averaging time-scale t_avg [seconds].
+        The time-averaged data, flags, time arrays, etc. are stored in avg_* attributes.
+        Note that although denoted avg_flags for consistency, this array stores the AND 
+        of flags in each averaging window.
+
+        The t_avg provided will be rounded to the nearest time that makes Navg 
+        an integer, and is stored as self.t_avg.
+
+        Parameters
+        ----------
+        t_avg : float
+            Width of time-averaging window in seconds.
+        """
+        # turn t_avg into Navg given dtime
+        Navg = int(np.round((t_avg /  (3600.0 * 24) / self.dtime)))
+        assert Navg > 0, "A t_avg of {:0.5f} makes Navg=0, which is too small.".format(t_avg)
+        if Navg > self.Ntimes:
+            Navg = self.Ntimes
+        old_t_avg = t_avg
+        t_avg = Navg * self.dtime * 3600.0 * 24
+
+        if verbose: 
+            print "The t_avg provided of {:.1f} has been shifted to {:.1f} to make Navg = {:d}".format(old_t_avg, t_avg, Navg)
+
+        # setup lists
+        avg_data = odict()
+        avg_flags = odict()
+        avg_nsamples = odict()
+
+        # iterate over keys
+        for i, k in enumerate(self.data.keys()):
+            ad, af, an, al, ea = timeavg_waterfall(self.data[k], Navg, flags=self.flags[k], nsamples=self.nsamples[k],
+                                                   rephase=rephase, lsts=self.lsts, freqs=self.freqs, bl_vec=self.blvecs[k[:2]],
+                                                   lat=self.lat, extra_arrays=dict(times=self.times), verbose=verbose)
+            avg_data[k] = ad
+            avg_flags[k] = af
+            avg_nsamples[k] = an
+
+        self.avg_data = hc.datacontainer.DataContainer(avg_data)
+        self.avg_flags = hc.datacontainer.DataContainer(avg_flags)
+        self.avg_nsamples = hc.datacontainer.DataContainer(avg_nsamples)
+        self.avg_lsts = al
+        self.avg_times = ea['avg_times']
+        self.t_avg = t_avg
+        self.Navg = Navg
+
+    def write_data(self, outfilename, write_avg=True, filetype='miriad', add_to_history='', overwrite=False):
+        """
+        Write data in FRFringe object. If write_avg == True, write the self.avg_data dictionary,
+        else write the self.data dictionary.
+
+        Parameters
+        ----------
+        outfilename : str
+            Path to output visibility data.
+
+        write_avg : bool
+            If True, write the avg_data dictionary, else write the data dictionary.
+
+        filetype : str
+            Output file format. Currently only miriad is supported.
+
+        add_to_history = str
+            History string to add to existing UVData object attached as self.inp_uvdata.
+
+        overwrite: bool
+            If True, overwrite output if it exists.
+        """
+        # check output
+        if os.path.exists(outfilename) and not overwrite:
+            print "{} already exists, not overwriting...".format(outfilename)
+            return
+
+        # create new UVData object
+        new_uvd = copy.deepcopy(self.inp_uvdata)
+
+        # set write data references
+        if write_avg:
+            data = self.avg_data
+            flags = self.avg_flags
+            nsamples = self.avg_nsamples
+            lsts = self.avg_lsts
+            times = self.avg_times
+        else:
+            data = self.data
+            flags = self.flags
+            nsamples = self.nsamples
+            lsts = self.lsts
+            times = self.times
+
+        # strip down to appropriate Ntimes
+        Ntimes = len(times)
+        new_uvd.select(times=self.times[:Ntimes], inplace=True)
+
+        # get telescope coords
+        lat, lon, alt = new_uvd.telescope_location_lat_lon_alt
+        lat = lat * 180 / np.pi
+        lon = lon * 180 / np.pi
+
+        # Overwrite data
+        for k in data.keys():
+            blts_inds = new_uvd.antpair2ind(*k[:2])
+            p = uvutils.polstr2num(k[2])
+            pol_ind = np.argmax(p in new_uvd.polarization_array)
+            new_uvd.data_array[blts_inds, 0, :, pol_ind] = data[k]
+            new_uvd.flag_array[blts_inds, 0, :, pol_ind] = flags[k]
+            new_uvd.nsample_array[blts_inds, 0, :, pol_ind] = nsamples[k]
+            new_uvd.time_array[blts_inds] = times
+            new_uvd.lst_array[blts_inds] = lsts
+            new_uvd.zenith_ra[blts_inds] = hc.utils.JD2RA(times, lon)
+            new_uvd.zenith_ra_degrees[blts_inds] = new_uvd.zenith_ra[blts_inds] * 180 / np.pi
+            new_uvd.zenith_dec[blts_inds] = lat * np.pi / 180
+            new_uvd.zenith_dec_degrees[blts_inds] = lat
+
+        # write data
+        if filetype == 'miriad':
+            new_uvd.write_miriad(outfilename, clobber=True)
+        else:
+            raise ValueError("filetype {} not recognized".format(filetype))
+
+        return new_uvd
+
+
+

--- a/uvtools/tests/test_frf.py
+++ b/uvtools/tests/test_frf.py
@@ -1,0 +1,98 @@
+import nose.tools as nt
+import os
+import shutil
+import numpy as np
+import sys
+from pyuvdata import UVData
+from pyuvdata import utils as uvutils
+import hera_cal as hc
+from uvtools.data import DATA_PATH
+from collections import OrderedDict as odict
+import copy
+import glob
+import uvtools as uvt
+
+
+def test_timeavg_waterfall():
+    fname = os.path.join(DATA_PATH, "zen.all.xx.LST.1.06964.uvA")
+
+    uvd = UVData()
+    uvd.read_miriad(fname)
+    
+    d = uvd.get_data(24, 25)
+    f = uvd.get_flags(24, 25)
+    n = uvd.get_nsamples(24, 25)
+    t = np.unique(uvd.time_array)
+    fr = uvd.freq_array.squeeze()
+    l = []
+    for _l in uvd.lst_array:
+        if _l not in l:
+            l.append(_l)
+    l = np.array(l)
+    antpos, ants = uvd.get_ENU_antpos()
+    blv = antpos[ants.tolist().index(24)] - antpos[ants.tolist().index(25)]
+
+    # test basic execution
+    ad, af, an, al, aea = uvt.frf.timeavg_waterfall(d, 4, verbose=False)
+    nt.assert_equal(ad.shape, (2, 1024))
+    nt.assert_equal(af.shape, (2, 1024))
+    nt.assert_equal(an.shape, (2, 1024))
+    nt.assert_false(np.any(af))
+    nt.assert_almost_equal(an[0, 0], 4.0)
+    nt.assert_almost_equal(an[1, 0], 2.0)
+
+    # test rephase
+    ad, af, an, al, aea = uvt.frf.timeavg_waterfall(d, 4, flags=f, rephase=True, lsts=l, freqs=fr, bl_vec=blv, 
+                                                    nsamples=n, extra_arrays=dict(times=t), verbose=False)
+    nt.assert_equal(ad.shape, (2, 1024))
+    nt.assert_equal(af.shape, (2, 1024))
+    nt.assert_equal(an.shape, (2, 1024))
+    nt.assert_true(np.any(af))
+    nt.assert_equal(len(al), 2)
+    nt.assert_equal(len(aea['avg_times']), 2)
+    nt.assert_almost_equal(an.max(), 98.0)
+
+
+class Test_FRFilter:
+
+    def setUp(self):
+        self.fname = os.path.join(DATA_PATH, "zen.all.xx.LST.1.06964.uvA")
+        self.F = uvt.frf.FRFilter()
+        self.uvd = UVData()
+        self.uvd.read_miriad(self.fname)
+
+    def test_load_data(self):
+        self.F.load_data(self.fname)
+        nt.assert_equal(self.F.inp_uvdata, self.uvd)
+        self.F.load_data(self.uvd)
+        nt.assert_equal(self.F.inp_uvdata, self.uvd)
+
+    def test_timeavg_data(self):
+        self.F.load_data(self.uvd)
+        self.F.timeavg_data(600.0, rephase=True)
+        nt.assert_equal(self.F.Navg, 3)
+
+        self.F.timeavg_data(1e10, rephase=True, verbose=False)
+        nt.assert_equal(self.F.Navg, 6)
+
+        # exceptions
+        nt.assert_raises(AssertionError, self.F.timeavg_data, 100.0)
+
+    def test_write_data(self):
+        self.F.load_data(self.uvd)
+        self.F.timeavg_data(600.0, rephase=False, verbose=False)
+        u = self.F.write_data("./out.uv", write_avg=True, filetype='miriad', overwrite=True)
+        nt.assert_true(os.path.exists("./out.uv"))
+        uv = UVData()
+        uv.read_miriad('./out.uv')
+        nt.assert_equal(u, uv)
+
+        u = self.F.write_data("./out.uv", overwrite=False)
+        nt.assert_equal(u, None)
+
+        u = self.F.write_data("./out.uv", write_avg=False, overwrite=True)
+        nt.assert_true(np.isclose(u.data_array, self.uvd.data_array).all())
+        if os.path.exists("./out.uv"):
+            shutil.rmtree("./out.uv")
+
+


### PR DESCRIPTION
Adds `frf.py` for Fringe Rate Filtering capabilities. In `frf.py`, however, there doesn't exist a traditional FRF (as is done in `fringe.py`), but currently only has simpler time averaging functions. At some point we should move over the more traditional fringe rate filtering code into the object oriented structure in `frf.py`. These basic capabilities provided here are what we need in the short-term for IDR2.1 analysis