### PR TITLE
Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ install:
   # create environment and install dependencies
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip matplotlib coverage basemap
   - source activate test-environment
-  - conda install -c conda-forge healpy aipy
+  - conda install -c conda-forge healpy
+  - pip install git+https://github.com/HERA-Team/aipy.git@v3.0.0rc1
   - pip install coveralls
   - pip install git+https://github.com/HERA-Team/pyuvdata.git
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
+  - "3.6"
+  
 install:
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
+  - conda config --remove channels defaults && conda config --add channels conda-forge
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
@@ -24,8 +25,7 @@ install:
   # create environment and install dependencies
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip matplotlib coverage basemap
   - source activate test-environment
-  - conda install -c conda-forge healpy
-  - pip install git+https://github.com/HERA-Team/aipy.git@v3.0.0rc1
+  - conda install -c conda-forge healpy aipy
   - pip install coveralls
   - pip install git+https://github.com/HERA-Team/pyuvdata.git
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda install -q conda=4.3.25
+  - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   # create environment and install dependencies
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip matplotlib coverage basemap
   - source activate test-environment
-  - conda install -c conda-forge aipy
+  - conda install -c conda-forge healpy aipy
   - pip install coveralls
   - pip install git+https://github.com/HERA-Team/pyuvdata.git
   - python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -37,4 +37,4 @@ setup_args = {
 
 
 if __name__ == '__main__':
-    apply(setup, (), setup_args)
+    setup(**setup_args)

--- a/uvtools/__init__.py
+++ b/uvtools/__init__.py
@@ -1,10 +1,10 @@
-import dspec
-import fringe
-import binning
-import plot
-import notebook
-import version
-import utils
+from . import dspec
+from . import fringe
+from . import binning
+from . import plot
+from . import notebook
+from . import version
+from . import utils
 
 __version__ = version.version
 

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -86,7 +86,7 @@ def high_pass_fourier_filter(data, wgts, filter_size, real_delta, tol=1e-9, wind
     elif data.ndim == 2:
         info = []
         d_mdl = np.empty_like(data)
-        for i in xrange(data.shape[0]):
+        for i in range(data.shape[0]):
             if _w[i,0] < skip_wgt: 
                 d_mdl[i] = 0 # skip highly flagged (slow) integrations
                 info.append({'skipped': True})

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -1,5 +1,6 @@
 import aipy
 import numpy as np
+from six.moves import range
 
 def wedge_width(bl_len, sdf, nchan, standoff=0., horizon=1.):
     '''Return the (upper,lower) delay bins that geometrically correspond to the sky.

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -35,8 +35,8 @@ def calc_width(filter_size, real_delta, nsamples):
             and ending at lthresh (which is a negative integer and also not filtered).
             Designed for area = np.ones(nsamples, dtype=np.int); area[uthresh:lthresh] = 0
     '''
-    bin_width = 1. / (real_delta * nsamples)
-    w = int(round(filter_size / bin_width))
+    bin_width = 1.0 / (real_delta * nsamples)
+    w = int(np.around(filter_size / bin_width))
     uthresh, lthresh = w + 1, -w
     if lthresh == 0: 
         lthresh = nsamples

--- a/uvtools/fringe.py
+++ b/uvtools/fringe.py
@@ -48,7 +48,7 @@ def fit_mdl(frp, bins, maxfr, mdl=gauss, maxfun=1000, ftol=1e-6, xtol=1e-6, star
     """
     bestargs, score = aipy.optimize.fmin(mdl_wrap, x0=startprms, args=(frp,bins,maxfr,mdl),
         full_output=1, disp=0, maxfun=maxfun, maxiter=np.Inf, ftol=ftol, xtol=xtol)[:2]
-    if verbose: print 'Final prms:', bestargs, 'Score:', score
+    if verbose: print('Final prms:', bestargs, 'Score:', score)
     return bestargs
 
 # XXX wgt and iwgt seem icky
@@ -67,7 +67,7 @@ def hmap_to_fr_profile(bm_hmap, bl, lat, bins=DEFAULT_FRBINS, wgt=DEFAULT_WGT, i
         fng = mk_fng(bl,eq)
     return fr_profile(bm, fng, bins=bins, wgt=wgt, iwgt=iwgt)
 
-def aa_to_fr_profile(aa, (i,j), ch, pol='I', bins=DEFAULT_FRBINS, wgt=DEFAULT_WGT, iwgt=DEFAULT_IWGT, nside=64, bl_scale=1,alietal=False, **kwargs):
+def aa_to_fr_profile(aa, i, j, ch, pol='I', bins=DEFAULT_FRBINS, wgt=DEFAULT_WGT, iwgt=DEFAULT_IWGT, nside=64, bl_scale=1, alietal=False, **kwargs):
     '''For an AntennaArray, for a baseline indexed by i,j, at frequency fq, return the fringe-rate profile.'''
     fq = aa.get_afreqs()[ch]
     h = aipy.healpix.HealpixMap(nside=nside)
@@ -157,7 +157,7 @@ def apply_frf(aa, data, wgts, i, j, pol='I', firs=None, alietal=False,
     if firs is None: firs = {}
     tbins = None
     if not firs.has_key((i,j,pol)):
-        frp,bins = aa_to_fr_profile(aa, (i,j), ch0, pol=pol, alietal=alietal,
+        frp,bins = aa_to_fr_profile(aa, i, j, ch0, pol=pol, alietal=alietal,
                                     **kwargs)
         del(kwargs['bins'])
         tbins, firs[(i,j,pol)] = frp_to_firs(frp, bins, freqs, fq0=fq0, **kwargs)

--- a/uvtools/plot.py
+++ b/uvtools/plot.py
@@ -28,8 +28,8 @@ def plot_hmap_ortho(h, cmap='jet', mode='log', mx=None, drng=None,
     from mpl_toolkits.basemap import Basemap
     m = Basemap(projection='ortho',lat_0=90,lon_0=180,rsphere=1.)
     if verbose:
-        print 'SCHEME:', h.scheme()
-        print 'NSIDE:', h.nside()
+        print('SCHEME:', h.scheme())
+        print('NSIDE:', h.nside())
     lons,lats,x,y = m.makegrid(360/res,180/res, returnxy=True)
     lons = 360 - lons
     lats *= aipy.img.deg2rad; lons *= aipy.img.deg2rad

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -13,7 +13,7 @@ class TestMethods(unittest.TestCase):
     def test_wedge_width(self):
         # Test boundaries of delay bins
         self.assertEqual(dspec.wedge_width(0, .01, 10), (1,10))
-        self.assertEqual(dspec.wedge_width(5., .01, 10), (2,-1))
+        self.assertEqual(dspec.wedge_width(5., .01, 10), (1,10))
         self.assertEqual(dspec.wedge_width( 9., .01, 10), (2,-1))
         self.assertEqual(dspec.wedge_width(10., .01, 10), (2,-1))
         self.assertEqual(dspec.wedge_width(15., .01, 10), (3,-2))
@@ -25,7 +25,7 @@ class TestMethods(unittest.TestCase):
         self.assertEqual(dspec.wedge_width(10., .04, 10), (5,-4))
         # test standoff
         self.assertEqual(dspec.wedge_width(100., .001, 100, standoff=4.), (11,-10))
-        self.assertEqual(dspec.wedge_width(100., .001, 100, standoff=5.), (12,-11))
+        self.assertEqual(dspec.wedge_width(100., .001, 100, standoff=5.), (11,-10))
         self.assertEqual(dspec.wedge_width(100., .001, 100, standoff=10.), (12,-11))
         self.assertEqual(dspec.wedge_width(100., .001, 100, standoff=15.), (13,-12))
         # test horizon

--- a/uvtools/version.py
+++ b/uvtools/version.py
@@ -6,7 +6,6 @@ uvtools_dir = os.path.dirname(os.path.realpath(__file__))
 version_file = os.path.join(uvtools_dir, 'VERSION')
 version = open(version_file).read().strip()
 
-
 def construct_version_info():
     uvtools_dir = os.path.dirname(os.path.realpath(__file__))
     version_file = os.path.join(uvtools_dir, 'VERSION')
@@ -15,22 +14,22 @@ def construct_version_info():
     try:
         git_origin = subprocess.check_output(['git', '-C', uvtools_dir, 'config',
                                               '--get', 'remote.origin.url'],
-                                             stderr=subprocess.STDOUT).strip()
+                                             stderr=subprocess.STDOUT).strip().decode()
         git_hash = subprocess.check_output(['git', '-C', uvtools_dir, 'rev-parse', 'HEAD'],
-                                           stderr=subprocess.STDOUT).strip()
+                                           stderr=subprocess.STDOUT).strip().decode()
         git_description = subprocess.check_output(['git', '-C', uvtools_dir,
-                                                   'describe', '--dirty', '--tag', '--always']).strip()
+                                                   'describe', '--dirty', '--tag', '--always']).strip().decode()
         git_branch = subprocess.check_output(['git', '-C', uvtools_dir, 'rev-parse',
                                               '--abbrev-ref', 'HEAD'],
-                                             stderr=subprocess.STDOUT).strip()
+                                             stderr=subprocess.STDOUT).strip().decode()
         git_version = subprocess.check_output(['git', '-C', uvtools_dir, 'describe', '--always',
-                                               '--tags', '--abbrev=0']).strip()
+                                               '--tags', '--abbrev=0']).strip().decode()
     except:  # pragma: no cover  - can't figure out how to test exception.
         try:
             # Check if a GIT_INFO file was created when installing package
             git_file = os.path.join(uvtools_dir, 'GIT_INFO')
             with open(git_file) as data_file:
-                data = [x.encode('UTF8') for x in json.loads(data_file.read().strip())]
+                data = [x for x in json.loads(data_file.read().strip())]
                 git_origin = data[0]
                 git_hash = data[1]
                 git_description = data[2]


### PR DESCRIPTION
makes repo python3 compatible.

There are two subtle API changes necessary to make it py3 compatible:

1. `(i,j)` --> `i, j` in `uvtools.fringe.aa_to_fr_profile`, but I don't think anyone uses this so it shouldn't be a big deal. We don't even cover this module in the travis tests here, meaning it isn't technically "graduated" collaboration code yet anyways

2. in `dspec.calc_width` I replaced the built-in `round` with `np.around`, the former is different depending on py2 vs py3 , the latter is not.