### PR TITLE
updated dspec.high_pass* handling of residual term

### DIFF
--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -162,7 +162,7 @@ def high_pass_fourier_filter(data, wgts, filter_size, real_delta, clean2d=False,
                     info.append({'skipped': True})
                 else:
                     _d_cl, info_here = aipy.deconv.clean(_d[i], _w[i], area=area, tol=tol, stop_if_div=False, maxiter=maxiter, gain=gain)
-                    d_mdl[i] = np.fft.fft(_d_cl + info_here['res'] * area)
+                    d_mdl[i] = np.fft.fft(_d_cl)
                     del info_here['res']
                     info.append(info_here)
 
@@ -197,7 +197,7 @@ def high_pass_fourier_filter(data, wgts, filter_size, real_delta, clean2d=False,
             
         # run clean
         _d_cl, info = aipy.deconv.clean(_d, _w, area=area, tol=tol, stop_if_div=False, maxiter=maxiter, gain=gain)
-        d_mdl = np.fft.fft2(_d_cl + info['res'] * area, axes=(0, 1))
+        d_mdl = np.fft.fft2(_d_cl, axes=(0, 1))
         del info['res']
 
     d_res = data - d_mdl

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -33,8 +33,7 @@ def wedge_width(bl_len, sdf, nchan, standoff=0., horizon=1.):
 
 
 def calc_width(filter_size, real_delta, nsamples):
-    '''Calculate the upper and lower bin indices of a fourier filter,
-    assuming mode ordering convention of np.fft.ifft
+    '''Calculate the upper and lower bin indices of a fourier filter
 
     Arguments:
         filter_size: the half-width (i.e. the width of the positive part) of the region in fourier
@@ -51,8 +50,8 @@ def calc_width(filter_size, real_delta, nsamples):
             Designed for area = np.ones(nsamples, dtype=np.int); area[uthresh:lthresh] = 0
     '''
     if isinstance(filter_size, (list, tuple, np.ndarray)):
-        _, l = calc_width(np.abs(filter_size[1]), real_delta, nsamples)
-        u, _ = calc_width(np.abs(filter_size[0]), real_delta, nsamples)
+        _, l = calc_width(np.abs(filter_size[0]), real_delta, nsamples)
+        u, _ = calc_width(np.abs(filter_size[1]), real_delta, nsamples)
         return (u, l)        
     bin_width = 1.0 / (real_delta * nsamples)
     w = int(np.around(filter_size / bin_width))

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -210,16 +210,15 @@ def high_pass_fourier_filter(data, wgts, filter_size, real_delta, clean2d=False,
     # add residual in CLEAN bounds if requested
     if add_clean_residual:
         _d_cl += _d_res * area
-        _d_res -= _d_res * area
 
     # fft back to input space
     if clean2d:
         d_mdl = np.fft.fft2(_d_cl, axes=(0, 1))
-        d_res = np.fft.fft2(_d_res, axes=(0, 1))
 
     else:
         d_mdl = np.fft.fft(_d_cl)
-        d_res = np.fft.fft(_d_res)
+
+    d_res = data - d_mdl
 
     return d_mdl, d_res, info
 

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -50,7 +50,7 @@ def calc_width(filter_size, real_delta, nsamples):
             and ending at lthresh (which is a negative integer and also not filtered).
             Designed for area = np.ones(nsamples, dtype=np.int); area[uthresh:lthresh] = 0
     '''
-    if isinstance(filter_size, (list, tuple)):
+    if isinstance(filter_size, (list, tuple, np.ndarray)):
         _, l = calc_width(np.abs(filter_size[1]), real_delta, nsamples)
         u, _ = calc_width(np.abs(filter_size[0]), real_delta, nsamples)
         return (u, l)        
@@ -194,7 +194,7 @@ def high_pass_fourier_filter(data, wgts, filter_size, real_delta, clean2d=False,
             pass
         else:
             raise ValueError("Didn't recognize filt2d_mode {}".format(filt2d_mode))
-            
+
         # run clean
         _d_cl, info = aipy.deconv.clean(_d, _w, area=area, tol=tol, stop_if_div=False, maxiter=maxiter, gain=gain)
         d_mdl = np.fft.fft2(_d_cl, axes=(0, 1))

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -150,19 +150,23 @@ def high_pass_fourier_filter(data, wgts, filter_size, real_delta, clean2d=False,
             # For 1D data array run once
             _d_cl, info = aipy.deconv.clean(_d, _w, area=area, tol=tol, stop_if_div=False, maxiter=maxiter, gain=gain)
             d_mdl = np.fft.fft(_d_cl)
+            d_res = np.fft.fft(info['res'])
             del info['res']
 
         elif data.ndim == 2:
             # For 2D data array, iterate
             info = []
             d_mdl = np.empty_like(data)
+            d_res = np.empty_like(data)
             for i in range(data.shape[0]):
                 if _w[i, 0] < skip_wgt:
                     d_mdl[i] = 0 # skip highly flagged (slow) integrations
+                    d_res[i] = _d[i]
                     info.append({'skipped': True})
                 else:
                     _d_cl, info_here = aipy.deconv.clean(_d[i], _w[i], area=area, tol=tol, stop_if_div=False, maxiter=maxiter, gain=gain)
                     d_mdl[i] = np.fft.fft(_d_cl)
+                    d_res[i] = np.fft.fft(info_here['res'])
                     del info_here['res']
                     info.append(info_here)
 
@@ -198,9 +202,8 @@ def high_pass_fourier_filter(data, wgts, filter_size, real_delta, clean2d=False,
         # run clean
         _d_cl, info = aipy.deconv.clean(_d, _w, area=area, tol=tol, stop_if_div=False, maxiter=maxiter, gain=gain)
         d_mdl = np.fft.fft2(_d_cl, axes=(0, 1))
+        d_res = np.fft.fft2(info['res'], axes=(0, 1))
         del info['res']
-
-    d_res = data - d_mdl
 
     return d_mdl, d_res, info
 

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -42,16 +42,16 @@ class TestMethods(unittest.TestCase):
         TOL = 1e-6
         data = np.ones(NCHAN, dtype=np.complex)
         wgts = .5*np.ones(NCHAN, dtype=np.complex)
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
+        dmdl, dres, dcln, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
         np.testing.assert_allclose(data, dmdl, atol=NCHAN*TOL)
         np.testing.assert_allclose(dres, np.zeros_like(dres), atol=NCHAN*TOL)
         wgts[::16] = 0
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
+        dmdl, dres, dcln, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
         np.testing.assert_allclose(data, dmdl, atol=NCHAN*TOL)
         np.testing.assert_allclose(dres, np.zeros_like(dres), atol=NCHAN*TOL)
         data = np.random.normal(size=NCHAN)
         wgts = np.ones_like(data)
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=1e-9)
+        dmdl, dres, dcln, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=1e-9)
         self.assertAlmostEqual(np.average(data), np.average(dmdl), 3)
         self.assertAlmostEqual(np.average(dres), 0, 3)
 
@@ -61,17 +61,17 @@ class TestMethods(unittest.TestCase):
         TOL = 1e-6
         data = np.ones((NTIMES, NCHAN), dtype=np.complex)
         wgts = np.ones((NTIMES, NCHAN), dtype=np.complex)
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
+        dmdl, dres, dcln, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
         np.testing.assert_allclose(data, dmdl, atol=NCHAN*TOL)
         np.testing.assert_allclose(dres, np.zeros_like(dres), atol=NCHAN*TOL)
         wgts[:,::16] = 0;
         wgts*=.9 #tests to make sure wgts**2 normalization works
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
+        dmdl, dres, dcln, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
         np.testing.assert_allclose(data, dmdl, atol=NCHAN*TOL)
         np.testing.assert_allclose(dres, np.zeros_like(dres), atol=NCHAN*TOL)
         data = np.array(np.random.normal(size=(NTIMES,NCHAN)),dtype=complex)
         wgts = np.ones_like(data)
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=1e-9)
+        dmdl, dres, dcln, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=1e-9)
         np.testing.assert_allclose(np.average(data,axis=1), np.average(dmdl,axis=1), atol=1e-3)
         np.testing.assert_allclose(np.average(dres,axis=1), 0, atol=1e-3)
 
@@ -145,7 +145,6 @@ class TestMethods(unittest.TestCase):
         nt.assert_raises(ValueError, dspec.delay_filter_leastsq_1d,
                          data[0], flags[0], sigma, nmax=3, cn_guess=np.array([3]))
 
-
     def test_skip_wgt(self):
         NCHAN = 128
         NTIMES = 10
@@ -153,11 +152,11 @@ class TestMethods(unittest.TestCase):
         data = np.ones((NTIMES, NCHAN), dtype=np.complex)
         wgts = np.ones((NTIMES, NCHAN), dtype=np.complex)
         wgts[0, 0:-4] = 0
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL, skip_wgt=.1)
+        dmdl, dres, dcln, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL, skip_wgt=.1)
         np.testing.assert_allclose(data[1:,:], dmdl[1:,:], atol=NCHAN*TOL)
         np.testing.assert_allclose(dres[1:,:], np.zeros_like(dres)[1:,:], atol=NCHAN*TOL)
         np.testing.assert_allclose(dmdl[0,:], np.zeros_like(dmdl[0,:]), atol=NCHAN*TOL)
-        np.testing.assert_allclose(dres[0,:], data[0,:], atol=NCHAN*TOL)
+        np.testing.assert_allclose(dres[0,:], (data * wgts)[0,:], atol=NCHAN*TOL)
         self.assertEqual(len(info), NTIMES)
         self.assertTrue(info[0]['skipped'])
 
@@ -167,7 +166,7 @@ class TestMethods(unittest.TestCase):
         dt = 10.
         filter_size = 1e-2
         u, l = dspec.calc_width(filter_size, dt, nchan)
-        frs = -np.fft.fftfreq(nchan, dt)  # negative b/c of ifft convention
+        frs = np.fft.fftfreq(nchan, dt)  # negative b/c of ifft convention
         nt.assert_true(np.all(np.abs(frs[u:l]) > filter_size))
 
         # test multiple entries in filter_size
@@ -181,112 +180,106 @@ def test_vis_filter():
     uvd = UVData()
     uvd.read_miriad(os.path.join(DATA_PATH, "zen.2458042.17772.xx.HH.uvXA"), bls=[(24, 25)])
 
-    # simulate some data in fringe-rate and delay space
-    np.random.seed(0)
-    dfft = (np.random.normal(0, 1, uvd.Nfreqs * uvd.Ntimes).astype(np.complex) \
-         + 1j * np.random.normal(0, 1, uvd.Nfreqs * uvd.Ntimes)).reshape(uvd.Ntimes, uvd.Nfreqs)
-    dfft[2, 2] += 200
-    dfft[20, 20] += 50
-    d = np.fft.fft2(dfft)
-
-    # get snr of modes
-    davg = np.mean(np.abs(np.fft.fft(dfft, axis=0)), axis=0)
-    std = np.median(davg)
-    snr1 = davg[2] / std
-    snr2 = davg[20] / std
-
-    # simulate some flags
-    f = np.zeros_like(d, dtype=np.bool)
-    d[:, 20] += 1e3
-    f[:, 20] = True
-    d[20, :] += 1e3
-    f[20, :] = True
-
-    # get data, wgts
-    w = (~f).astype(np.float)
-    bl_len = 50 / 2.99e8
-    sdf = np.median(np.diff(uvd.freq_array.squeeze()))
-    dt = np.median(np.diff(np.unique(uvd.time_array))) * 24 * 3600
+    freqs = uvd.freq_array.squeeze()
+    times = np.unique(uvd.time_array) * 24 * 3600
+    times -= np.mean(times)
+    sdf = np.median(np.diff(freqs))
+    dt = np.median(np.diff(times))
     frs = np.fft.fftfreq(uvd.Ntimes, d=dt)
     dlys = np.fft.fftfreq(uvd.Nfreqs, d=sdf) * 1e9
 
+    # simulate some data in fringe-rate and delay space
+    np.random.seed(0)
+    dfr, ddly = frs[1] - frs[0], dlys[1] - dlys[0]
+    d = 200 * np.exp(-2j*np.pi*times[:, None]*(frs[2]+dfr/4) - 2j*np.pi*freqs[None, :]*(dlys[2]+ddly/4)/1e9)
+    d += 50 * np.exp(-2j*np.pi*times[:, None]*(frs[20]) - 2j*np.pi*freqs[None, :]*(dlys[20])/1e9)
+    d += 10 * ((np.random.normal(0, 1, uvd.Nfreqs * uvd.Ntimes).astype(np.complex) \
+         + 1j * np.random.normal(0, 1, uvd.Nfreqs * uvd.Ntimes)).reshape(uvd.Ntimes, uvd.Nfreqs))
+
     def get_snr(clean, fftax=1, avgax=0, modes=[2, 20]):
         cfft = np.fft.ifft(clean, axis=fftax)
-        cavg = np.mean(np.abs(cfft), axis=avgax)
+        cavg = np.median(np.abs(cfft), axis=avgax)
         std = np.median(cavg)
         return [cavg[m] / std for m in modes]
 
+    # get snr of modes
+    freq_snr1, freq_snr2 = get_snr(d, fftax=1, avgax=0, modes=[2, 20])
+    time_snr1, time_snr2 = get_snr(d, fftax=0, avgax=1, modes=[2, 20])
+
+    # simulate some flags
+    f = np.zeros_like(d, dtype=np.bool)
+    d[:, 20:22] += 1e3
+    f[:, 20:22] = True
+    d[20, :] += 1e3
+    f[20, :] = True
+    w = (~f).astype(np.float)
+    bl_len = 70.0 / 2.99e8
+
     # delay filter basic execution
-    mdl, res, info = dspec.delay_filter(d, w, bl_len, sdf, standoff=0, horizon=1.0, min_dly=0.0,
-                                        tol=1e-4, window='none', skip_wgt=0.1, gain=0.1)
+    mdl, res, cln, info = dspec.delay_filter(d, w, bl_len, sdf, standoff=0, horizon=1.0, min_dly=0.0,
+                                             tol=1e-4, window='none', skip_wgt=0.1, gain=0.1)
     # assert recovered snr of input modes
-    clean = mdl + res * w
-    snrs = get_snr(clean)
-    nt.assert_true(np.isclose(snrs[0], snr1, atol=2))
-    nt.assert_true(np.isclose(snrs[1], snr2, atol=2))
+    snrs = get_snr(cln, fftax=1, avgax=0)
+    nt.assert_true(np.isclose(snrs[0], freq_snr1, atol=3))
+    nt.assert_true(np.isclose(snrs[1], freq_snr2, atol=3))
 
     # test vis filter is the same
-    mdl2, res2, info2 = dspec.vis_filter(d, w, bl_len=bl_len, sdf=sdf, standoff=0, horizon=1.0, min_dly=0.0,
-                                           tol=1e-4, window='none', skip_wgt=0.1, gain=0.1)
+    mdl2, res2, cln2, info2 = dspec.vis_filter(d, w, bl_len=bl_len, sdf=sdf, standoff=0, horizon=1.0, min_dly=0.0,
+                                               tol=1e-4, window='none', skip_wgt=0.1, gain=0.1)
     nt.assert_true(np.isclose(mdl - mdl2, 0.0).all())
 
     # fringe filter basic execution 
-    mdl, res, info = dspec.fringe_filter(d, w, frs[15], dt, tol=1e-4, window='none', skip_wgt=0.1, gain=0.1)
+    mdl, res, cln, info = dspec.fringe_filter(d, w, frs[15], dt, tol=1e-4, window='none', skip_wgt=0.1, gain=0.1)
 
     # assert recovered snr of input modes
-    clean = mdl + res * w
-    snrs = get_snr(clean)
-    nt.assert_true(np.isclose(snrs[0], snr1, atol=2))
-    nt.assert_true(np.isclose(snrs[1], snr2, atol=2))
+    snrs = get_snr(cln, fftax=0, avgax=1)
+    nt.assert_true(np.isclose(snrs[0], time_snr1, atol=3))
+    nt.assert_true(np.isclose(snrs[1], time_snr2, atol=3))
 
     # test vis filter is the same
-    mdl2, res2, info2 = dspec.vis_filter(d, w, max_frate=frs[15], dt=dt, tol=1e-4, window='none', skip_wgt=0.1, gain=0.1)
+    mdl2, res2, cln2, info2 = dspec.vis_filter(d, w, max_frate=frs[15], dt=dt, tol=1e-4, window='none', skip_wgt=0.1, gain=0.1)
     nt.assert_true(np.isclose(mdl - mdl2, 0.0).all())
 
     # try non-symmetric filter
-    mdl, res, info = dspec.fringe_filter(d, w, (frs[-20], frs[10]), dt, tol=1e-4, window='none', skip_wgt=0.1, gain=0.1)
+    mdl, res, cln, info = dspec.fringe_filter(d, w, (frs[-20], frs[10]), dt, tol=1e-4, window='none', skip_wgt=0.1, gain=0.1)
 
     # assert recovered snr of input modes
-    clean = mdl + res * w
-    snrs = get_snr(clean)
-    nt.assert_true(np.isclose(snrs[0], snr1, atol=2))
-    nt.assert_true(np.isclose(snrs[1], snr2, atol=2))
+    snrs = get_snr(cln, fftax=0, avgax=1)
+    nt.assert_true(np.isclose(snrs[0], time_snr1, atol=3))
+    nt.assert_true(np.isclose(snrs[1], time_snr2, atol=3))
 
     # 2d clean
-    mdl, res, info = dspec.vis_filter(d, w, bl_len=bl_len, sdf=sdf, max_frate=frs[15], dt=dt, tol=1e-4, window='none', maxiter=100, gain=1e-1)
+    mdl, res, cln, info = dspec.vis_filter(d, w, bl_len=bl_len, sdf=sdf, max_frate=frs[15], dt=dt, tol=1e-4, window='none', maxiter=100, gain=1e-1)
 
     # assert recovered snr of input modes
-    clean = mdl + res * w
-    snrs = get_snr(clean)
-    nt.assert_true(np.isclose(snrs[0], snr1, atol=2))
-    nt.assert_true(np.isclose(snrs[1], snr2, atol=2))
+    snrs = get_snr(cln, fftax=1, avgax=0)
+    nt.assert_true(np.isclose(snrs[0], freq_snr1, atol=3))
+    nt.assert_true(np.isclose(snrs[1], freq_snr2, atol=3))
 
     # non-symmetric 2D clean
-    mdl, res, info = dspec.vis_filter(d, w, bl_len=bl_len, sdf=sdf, max_frate=(frs[-20], frs[10]), dt=dt, tol=1e-4, window='none', maxiter=100, gain=1e-1)
+    mdl, res, cln, info = dspec.vis_filter(d, w, bl_len=bl_len, sdf=sdf, max_frate=(frs[-20], frs[10]), dt=dt, tol=1e-4, window='none', maxiter=100, gain=1e-1)
 
     # assert recovered snr of input modes
-    clean = mdl + res * w
-    snrs = get_snr(clean)
-    nt.assert_true(np.isclose(snrs[0], snr1, atol=2))
-    nt.assert_true(np.isclose(snrs[1], snr2, atol=2))
+    snrs = get_snr(cln, fftax=1, avgax=0)
+    nt.assert_true(np.isclose(snrs[0], freq_snr1, atol=3))
+    nt.assert_true(np.isclose(snrs[1], freq_snr2, atol=3))
 
     # try plus filtmode on 2d clean
-    mdl, res, info = dspec.vis_filter(d, w, bl_len=bl_len, sdf=sdf, max_frate=(frs[-20], frs[10]), dt=dt, tol=1e-4, window=('none', 'blackman'), edgecut_low=(0, 5), edgecut_hi=(2, 5), maxiter=100, gain=1e-1, filt2d_mode='plus')
+    mdl, res, cln, info = dspec.vis_filter(d, w, bl_len=bl_len, sdf=sdf, max_frate=(frs[10], frs[10]), dt=dt, tol=1e-4, window=('none', 'none'), edgecut_low=(0, 5), edgecut_hi=(2, 5), maxiter=100, gain=1e-1, filt2d_mode='plus')
+    mfft = np.fft.ifft2(mdl)
 
-    # assert recovered snr of input modes
-    clean = mdl + res * w
-    snrs = get_snr(clean)
-    nt.assert_true(np.isclose(snrs[0], snr1, atol=2))
-    nt.assert_true(np.isclose(snrs[1], snr2, atol=2))
+    # assert clean components fall only in plus area
+    clean_comp = np.where(~np.isclose(np.abs(mfft), 0.0))
+    for cc in zip(*clean_comp):
+        nt.assert_true(0 in cc)
 
     # exceptions
     nt.assert_raises(ValueError, dspec.vis_filter, d, w, bl_len=bl_len, sdf=sdf, max_frate=(frs[-20], frs[10]), dt=dt, filt2d_mode='foo')
 
     # test add_clean_residual: test res of filtered modes are zero
-    mdl, res, info = dspec.vis_filter(d, w, bl_len=bl_len, sdf=sdf, max_frate=frs[15], dt=dt, tol=1e-6, window='none', maxiter=100, gain=1e-1, add_clean_residual=True)
+    mdl, res, cln, info = dspec.vis_filter(d, w, bl_len=bl_len, sdf=sdf, max_frate=frs[15], dt=dt, tol=1e-6, window='none', maxiter=100, gain=1e-1, add_clean_residual=True)
     rfft = np.fft.ifft2(res)
     nt.assert_true(np.isclose(np.abs(rfft[:15, :17]), 0.0).all())
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -282,6 +282,11 @@ def test_vis_filter():
     # exceptions
     nt.assert_raises(ValueError, dspec.vis_filter, d, w, bl_len=bl_len, sdf=sdf, max_frate=(frs[-20], frs[10]), dt=dt, filt2d_mode='foo')
 
+    # test add_clean_residual: test res of filtered modes are zero
+    mdl, res, info = dspec.vis_filter(d, w, bl_len=bl_len, sdf=sdf, max_frate=frs[15], dt=dt, tol=1e-6, window='none', maxiter=100, gain=1e-1, add_clean_residual=True)
+    rfft = np.fft.ifft2(res)
+    nt.assert_true(np.isclose(np.abs(rfft[:15, :17]), 0.0).all())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Updates how `dspec.high_pass_fourier_filter` handles the residual term. It makes adding the residual within the CLEAN window to the model optional, and uses the residual from `aipy.deconv.clean`, rather than re-compute it at the end as `data - model`. This was done because for a pure filtering process, one really should be adding the residual within the filtering window to the model, but b/c this module does both CLEANing and filtering, I wanted to make it optional.

The function now also outputs the "CLEANed" data, which is `mdl + res`.