### PR TITLE
Add basemap package to install reqs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION coverage coveralls
   - source activate test-environment
   - conda env update -n test-environment -f environment.yml
+  - pip install --user git+https://github.com/matplotlib/basemap.git # workaround
   - pip install .
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION coverage coveralls
   - source activate test-environment
   - conda env update -n test-environment -f environment.yml
-  - conda install basemap
   - pip install .
 
 before_script:

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,5 @@ dependencies:
   - pyuvdata
   - scipy
   - pip
+  - basemap
 

--- a/environment.yml
+++ b/environment.yml
@@ -9,5 +9,3 @@ dependencies:
   - pyuvdata
   - scipy
   - pip
-  - basemap
-

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ setup_args = {
         'numpy',
         'aipy>=3.0rc2',
         'six',
-        'scipy'
+        'scipy',
+        'basemap'
     ]
 }
 


### PR DESCRIPTION
The `basemap` package is now required by some of the plotting functions. This PR adds it to the `setup.py` list of required packages.