### PR TITLE
Plot diff 1d

### DIFF
--- a/uvtools/plot.py
+++ b/uvtools/plot.py
@@ -872,10 +872,10 @@ def plot_diff_1d(uvd1, uvd2, antpairpol, plot_type="both",
               }
 
     # and now for ordinate labels
-    vis_labels = {"time" : r"$V(t)$ [Jy]",
-                  "freq" : r"$V(\nu)$ [Jy]",
-                  "fr" : r"$\tilde{V}(f)$ [Jy$\cdot$s]",
-                  "dly" : r"$\tilde{V}(\tau)$ [Jy$\cdot$Hz]"
+    vis_labels = {"time" : r"$V(t)$ [{vis_units}]",
+                  "freq" : r"$V(\nu)$ [{vis_units}]",
+                  "fr" : r"$\tilde{V}(f)$ [{vis_units}$\cdot$s]",
+                  "dly" : r"$\tilde{V}(\tau)$ [{vis_units}$\cdot$Hz]"
                   }
 
     # make some mappings for plot types
@@ -920,7 +920,9 @@ def plot_diff_1d(uvd1, uvd2, antpairpol, plot_type="both",
         )
 
         xdim = item[0]
-        xlabel, ylabel = labels[xdim], vis_labels[xdim]
+        xlabel = labels[xdim]
+        # to ensure appropriate LaTeX formatting and visibility units
+        ylabel = vis_labels[xdim].format(V="{V}", vis_units=uvd1.vis_units)
 
         # actually plot it
         for ax, diff in zip(axes[i], diffs):

--- a/uvtools/plot.py
+++ b/uvtools/plot.py
@@ -723,3 +723,6 @@ def plot_diff_uv(uvd1, uvd2, pol=None, check_metadata=True, bins=50):
         fig.colorbar(cax)
 
     return fig
+
+def plot_diff_1d(uvd1, uvd2, **kwargs):
+    pass

--- a/uvtools/plot.py
+++ b/uvtools/plot.py
@@ -726,7 +726,6 @@ def plot_diff_uv(uvd1, uvd2, pol=None, check_metadata=True, bins=50):
 
 def plot_diff_1d(uvd1, uvd2, antpairpol, plot_type="both", 
                  check_metadata=True, dimension=None):
-    # TODO: docstring
     """Produce plots of visibility differences along a single axis.
 
     Parameters

--- a/uvtools/plot.py
+++ b/uvtools/plot.py
@@ -743,9 +743,9 @@ def plot_diff_1d(uvd1, uvd2, antpairpol, plot_type="both",
     plot_type : str, optional
         A string identifying which quantities to plot. Accepted values are 
         as follows:
-            - base
+            - normal
                 - Single row of plots in the usual basis (time or frequency).
-            - dual
+            - fourier
                 - Single row of plots in Fourier space (fringe rate or delay).
             - both
                 - Two rows of plots in the usual and Fourier domains.
@@ -760,7 +760,7 @@ def plot_diff_1d(uvd1, uvd2, antpairpol, plot_type="both",
         Default behavior is to check the metadata.
     
     dimension : str, optional
-        String specifying which dimension is used for the base domain. This 
+        String specifying which dimension is used for the normal domain. This 
         may be either 'time' or 'freq'. Default is to determine which axis has
         more entries and to use that axis.
 
@@ -781,14 +781,14 @@ def plot_diff_1d(uvd1, uvd2, antpairpol, plot_type="both",
     if check_metadata:
         utils.check_uvd_pair_metadata(uvd1, uvd2)
 
-    if plot_type not in ("base", "dual", "both"):
+    if plot_type not in ("normal", "fourier", "both"):
         raise ValueError(
             "You must specify whether to make one or two plots with "
             "the ``plot_type`` parameter. You may choose to plot the "
             "visibility difference as a function of frequency/time by "
-            "setting ``plot_type`` to 'base', or you can choose to "
+            "setting ``plot_type`` to 'normal', or you can choose to "
             "plot the difference in Fourier space by setting "
-            "``plot_type`` to 'dual'. If you would like to plot both, "
+            "``plot_type`` to 'fourier'. If you would like to plot both, "
             "then set ``plot_type`` to 'both'."
         )
 
@@ -858,9 +858,9 @@ def plot_diff_1d(uvd1, uvd2, antpairpol, plot_type="both",
                   }
 
     # update the plot_type parameter to something useful
-    if plot_type == "base":
+    if plot_type == "normal":
         plot_type = (dimension,)
-    elif plot_type == "dual":
+    elif plot_type == "fourier":
         plot_type = (dual,)
     else:
         plot_type = (dimension, dual)

--- a/uvtools/tests/test_plot.py
+++ b/uvtools/tests/test_plot.py
@@ -97,6 +97,10 @@ class TestDiffPlotters(unittest.TestCase):
         sim.add_eor("noiselike_eor")
         self.uvd2 = copy.deepcopy(sim.data)
         # now just make some things with metadata that will raise exceptions
+
+        # make the visibility units disagree
+        sim.data.vis_units = 'mK'
+        self.uvd_bad_vis_units = copy.deepcopy(sim.data)
         # mismatched baselines
         sim = hera_sim.Simulator(n_freq=10, n_times=10, 
                                  antennas=offset_ants,
@@ -285,7 +289,7 @@ class TestDiffPlotters(unittest.TestCase):
             if not attr.startswith("uvd_bad"):
                 continue
             print("testing on: {}".format(attr))
-            nt.assert_raises(AssertionError, 
+            nt.assert_raises(uvt.utils.MetadataError, 
                              uvt.plot.plot_diff_uv,
                              self.uvd1, value,
                              check_metadata=True)

--- a/uvtools/tests/test_plot.py
+++ b/uvtools/tests/test_plot.py
@@ -152,7 +152,7 @@ class TestDiffPlotters(unittest.TestCase):
 
     def test_plot_diff_1d(self):
         # list possible plot types and dimensions
-        plot_types = ("base", "dual", "both")
+        plot_types = ("normal", "fourier", "both")
         dimensions = ("time", "freq")
         duals = {"time" : "fringe rate", "freq" : "delay"}
 
@@ -174,9 +174,9 @@ class TestDiffPlotters(unittest.TestCase):
                     xlabel = ax.get_xlabel().lower()
 
                     # find out what the dimension should be
-                    if plot_type == "base":
+                    if plot_type == "normal":
                         dim = dimension
-                    elif plot_type == "dual":
+                    elif plot_type == "fourier":
                         dim = duals[dimension]
                     else:
                         dim = dimension if i // 3 == 0 else duals[dimension]
@@ -194,7 +194,7 @@ class TestDiffPlotters(unittest.TestCase):
 
         # make just one row of plots
         fig = uvt.plot.plot_diff_1d(
-            self.sim.data, self.sim.data, self.antpairpol, plot_type="base"
+            self.sim.data, self.sim.data, self.antpairpol, plot_type="normal"
         )
 
         # make sure that it's plotting in frequency space

--- a/uvtools/tests/test_plot.py
+++ b/uvtools/tests/test_plot.py
@@ -154,7 +154,7 @@ class TestDiffPlotters(unittest.TestCase):
 
         # loop over all the choices
         for plot_type in plot_types:
-            Nplots = 6 if plot_types == "both" else 3
+            Nplots = 6 if plot_type == "both" else 3
             elements = [(plt.Subplot, Nplots),]
             for dimension in dimensions:
                 fig = uvt.plot.plot_diff_1d(

--- a/uvtools/tests/test_plot.py
+++ b/uvtools/tests/test_plot.py
@@ -137,8 +137,12 @@ class TestDiffPlotters(unittest.TestCase):
         # choose an antenna pair and polarization for later
         self.antpairpol = (0, 1, "xx")
 
-        # make a copy of the antenna array for the plot_diff_1d test
-        self.antennas = antennas
+        # make a simulation for the plot_diff_1d test
+        sim = hera_sim.Simulator(
+            n_freq=100, n_times=2, antennas=antennas
+        )
+        sim.add_eor("noiselike_eor")
+        self.sim = sim
 
     def tearDown(self):
         pass
@@ -187,16 +191,10 @@ class TestDiffPlotters(unittest.TestCase):
         plt.close(fig)
 
         # now test the auto-dimension-choosing feature
-        # first, mock up some data; need at least 2 times for fringe filter
-        sim = hera_sim.Simulator(
-            n_freq=100, n_times=2, antennas=self.antennas
-        )
-
-        sim.add_eor("noiselike_eor")
 
         # make just one row of plots
         fig = uvt.plot.plot_diff_1d(
-            sim.data, sim.data, self.antpairpol, plot_type="base"
+            self.sim.data, self.sim.data, self.antpairpol, plot_type="base"
         )
 
         # make sure that it's plotting in frequency space

--- a/uvtools/tests/test_plot.py
+++ b/uvtools/tests/test_plot.py
@@ -175,8 +175,12 @@ class TestDiffPlotters(unittest.TestCase):
                     elif plot_type == "dual":
                         dim = duals[dimension]
                     else:
-                        dim = duals[dimension] if i // 3 else dimension
+                        dim = dimension if i // 3 == 0 else duals[dimension]
                     
+                    # account for the fact that it plots against lst if
+                    # plotting along the time axis
+                    dim = "lst" if dim == "time" else dim
+
                     # make sure that the label is correct
                     self.assertTrue(xlabel.startswith(dim))
 


### PR DESCRIPTION
This PR adds a new method to the `plot` module that allows the user to plot differences between 1d visibility arrays (or, alternatively, plot the difference between waterfalls averaged over an axis). The implementation is similar to the other `plot_diff` functions, but refactoring will be postponed until a later update.