### PR TITLE
Allow tapers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ install:
   - source activate test-environment
   - conda env update -n test-environment -f environment.yml
   - pip install --user git+https://github.com/matplotlib/basemap.git # workaround
+  - pip install pyradiosky
   - pip install git+https://github.com/HERA-Team/hera_sim.git
-  - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyradiosky.git
   - pip install .
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
   - conda env update -n test-environment -f environment.yml
   - pip install --user git+https://github.com/matplotlib/basemap.git # workaround
   - pip install git+https://github.com/HERA-Team/hera_sim.git
+  - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyradiosky.git
   - pip install .
 
 before_script:

--- a/uvtools/plot.py
+++ b/uvtools/plot.py
@@ -758,6 +758,7 @@ def plot_diff_uv(uvd1, uvd2, pol=None, check_metadata=True, bins=50):
 
 def plot_diff_1d(uvd1, uvd2, antpairpol, plot_type="both", 
                  check_metadata=True, dimension=None,
+                 taper=None, taper_kwargs=None,
                  average_mode=None, **kwargs):
     """Produce plots of visibility differences along a single axis.
 
@@ -796,6 +797,15 @@ def plot_diff_1d(uvd1, uvd2, antpairpol, plot_type="both",
         String specifying which dimension is used for the normal domain. This 
         may be either 'time' or 'freq'. Default is to determine which axis has
         more entries and to use that axis.
+
+    taper : str, optional
+        Sting specifying which taper to use; must be a taper supported by 
+        ``dspec.gen_window``. Default is to use no taper.
+
+    taper_kwargs : dict, optional
+        Dictionary of keyword arguments and their values, passed downstream to 
+        ``dspec.gen_window``. Default is to use an empty dictionary (i.e. 
+        default parameter values for whatever window is generated).
 
     average_mode : str, optional
         String specifying which ``numpy`` averaging function to use. Default 
@@ -869,7 +879,6 @@ def plot_diff_1d(uvd1, uvd2, antpairpol, plot_type="both",
         except AttributeError as err:
             err_msg = err.args[0] + "\nDefaulting to using np.mean"
             warnings.warn(err_msg)
-        finally:
             average = np.mean
     else:
         average = np.mean
@@ -910,9 +919,12 @@ def plot_diff_1d(uvd1, uvd2, antpairpol, plot_type="both",
                   "dly" : r"$\tilde{V}(\tau)$ [{vis_units}$\cdot$Hz]"
                   }
 
+    # make sure the taper kwargs are a dictionary
+    taper_kwargs = taper_kwargs or {}
+
     # make some mappings for plot types
     plot_types = {dimension : lambda data : data, # no fft
-                  dual : lambda data : utils.FFT(data, 0)
+                  dual : lambda data : utils.FFT(data, 0, taper, **taper_kwargs)
                   }
 
     # update the plot_type parameter to something useful

--- a/uvtools/plot.py
+++ b/uvtools/plot.py
@@ -472,7 +472,7 @@ def omni_view_gif(filenames, name='omni_movie.gif'):
     imageio.mimsave(name, images)
     
 def plot_diff_waterfall(uvd1, uvd2, antpairpol, plot_type="all", 
-                        check_metadata=True):
+                        check_metadata=True, taper=None):
     """Produce waterfall plot(s) of differenced visibilities.
 
     Parameters
@@ -536,9 +536,9 @@ def plot_diff_waterfall(uvd1, uvd2, antpairpol, plot_type="all",
 
     # map plot types to transforms needed
     plot_types = {"time_vs_freq" : lambda data : data, # do nothing
-                  "time_vs_dly" : lambda data : utils.FFT(data, 1), # FFT in freq
+                  "time_vs_dly" : lambda data : utils.FFT(data, 1, taper), # FFT in freq
                   "fr_vs_freq" : lambda data : utils.FFT(data, 0), # FFT in time
-                  "fr_vs_dly" : lambda data : utils.FFT(utils.FFT(data, 0), 1), # both
+                  "fr_vs_dly" : lambda data : utils.FFT(utils.FFT(data, 0), 1, taper), # both
                   }
 
     # convert plot type to tuple

--- a/uvtools/tests/test_plot.py
+++ b/uvtools/tests/test_plot.py
@@ -221,6 +221,16 @@ class TestDiffPlotters(unittest.TestCase):
             # now close the figure
             plt.close(fig)
 
+    def test_plot_diff_waterfall_with_tapers(self):
+        # since the above test makes sure the figures are correctly configured,
+        # this one will just make sure nothing breaks when a taper is specified
+        fig = uvt.plot.plot_diff_waterfall(
+            self.uvd1, self.uvd2, self.antpairpol, freq_taper='blackman-harris',
+            time_taper='hann'
+        )
+
+        plt.close(fig)
+
     def test_bad_metadata(self):
         for attr, value in self.__dict__.items():
             if not attr.startswith("uvd_bad"):

--- a/uvtools/utils.py
+++ b/uvtools/utils.py
@@ -121,12 +121,11 @@ def FFT(data, axis, taper=None):
         has the same shape as the original data, with the same ordering.
     """
     if taper is not None:
-        window = dspec.gen_window(taper, data.shape[axis])
-        window = fftshift(fft(window)).reshape(1,-1)
+        window = dspec.gen_window(taper, data.shape[axis]).reshape(1,-1)
     else:
         window = np.ones(data.shape)
 
-    return window * fftshift(fft(data, axis=axis), axis)
+    return fftshift(fft(window * data, axis=axis), axis)
 
 def fourier_freqs(times):
     """A function for generating Fourier frequencies given 'times'.

--- a/uvtools/utils.py
+++ b/uvtools/utils.py
@@ -2,6 +2,7 @@ from numpy.fft import fft, fftshift
 import numpy as np
 import glob
 
+from . import dspec
 
 def search_data(templates, pols, matched_pols=False, reverse_nesting=False, flatten=False):
     """
@@ -101,7 +102,7 @@ def search_data(templates, pols, matched_pols=False, reverse_nesting=False, flat
 
     return datafiles, datapols
 
-def FFT(data, axis):
+def FFT(data, axis, taper=None):
     """Convenient function for performing a FFT along an axis.
 
     Parameters
@@ -119,8 +120,13 @@ def FFT(data, axis):
         The Fourier transform of the data along the specified axis. The array
         has the same shape as the original data, with the same ordering.
     """
+    if taper is not None:
+        window = dspec.gen_window(taper, data.shape[axis])
+        window = fftshift(fft(window)).reshape(1,-1)
+    else:
+        window = np.ones(data.shape)
 
-    return fftshift(fft(data, axis=axis), axis)
+    return window * fftshift(fft(data, axis=axis), axis)
 
 def fourier_freqs(times):
     """A function for generating Fourier frequencies given 'times'.

--- a/uvtools/utils.py
+++ b/uvtools/utils.py
@@ -102,7 +102,7 @@ def search_data(templates, pols, matched_pols=False, reverse_nesting=False, flat
 
     return datafiles, datapols
 
-def FFT(data, axis, taper=None):
+def FFT(data, axis, taper=None, **kwargs):
     """Convenient function for performing a FFT along an axis.
 
     Parameters
@@ -114,16 +114,23 @@ def FFT(data, axis, taper=None):
     axis : int
         The axis to perform the FFT over.
 
+    taper : str, optional
+        Choice of taper (windowing function) to apply to the data. Default is 
+        to use no taper.
+
+    **kwargs
+        Keyword arguments for generating the taper. Passed directly to 
+        ``uvtools.dspec.gen_window``.
+
     Returns
     -------
     data_fft : np.ndarray
         The Fourier transform of the data along the specified axis. The array
         has the same shape as the original data, with the same ordering.
     """
-    if taper is not None:
-        window = dspec.gen_window(taper, data.shape[axis]).reshape(1,-1)
-    else:
-        window = np.ones(data.shape)
+    window = dspec.gen_window(taper, data.shape[axis], **kwargs)
+    new_shape = tuple([1 if ax != axis else -1 for ax in range(data.ndim)])
+    window.shape = new_shape
 
     return fftshift(fft(window * data, axis=axis), axis)
 


### PR DESCRIPTION
This PR extends the functionality of `plot.plot_diff_waterfall` and `utils.FFT` to allow a taper to be applied when taking a Fourier transform along a given axis. This supports windowing in time and frequency (in fact, `utils.FFT` should be general enough to support windowing along an arbitrary axis for an N-dimensional array).