### PR TITLE
Make cleaning area behavior of fourier filter match up with high_pass_fourier_filter

### DIFF
--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -67,12 +67,12 @@ def _fourier_filter_hash(filter_centers, filter_half_widths,
     -------
     A key for fourier_filter arrays hasing the information provided in the args.
     '''
-    filter_key = tuple(np.round(x,hash_decimal))\
-    + tuple(np.round(np.asarray(filter_centers) * np.mean(np.diff(x)) * len(x), hash_decimal))\
-    + tuple(np.round(np.asarray(filter_half_widths) * np.mean(np.diff(x)) * len(x), hash_decimal))\
-    + tuple(np.round(np.asarray(filter_factors) * 1e9, hash_decimal))
+    filter_key = ('x:',) + tuple(np.round(x,hash_decimal))\
+    + ('filter_centers x N x DF:',) + tuple(np.round(np.asarray(filter_centers) * np.mean(np.diff(x)) * len(x), hash_decimal))\
+    + ('filter_centers x N x DF:',) + tuple(np.round(np.asarray(filter_half_widths) * np.mean(np.diff(x)) * len(x), hash_decimal))\
+    + ('filter_factors x 1e9:',) + tuple(np.round(np.asarray(filter_factors) * 1e9, hash_decimal))
     if w is not None:
-        filter_key = filter_key + tuple(np.round(w.tolist(), hash_decimal))
+        filter_key = filter_key + ('weights', ) +  tuple(np.round(w.tolist(), hash_decimal))
     filter_key = filter_key + tuple([kwargs[k] for k in kwargs])
     return filter_key
 
@@ -1002,7 +1002,7 @@ def dayenu_filter(x, data, wgts, filter_dimensions, filter_centers, filter_half_
                 if not isinstance(x[j], (tuple, list, np.ndarray)):
                     raise ValueError("x[%d] must be a tuple, list or numpy array."%(j))
                 x[j]=np.asarray(x[j])
-        for ff_num,ff_list in zip([0,1],filter_factors):
+        for ff_num,ff_list in zip(filter_dimensions,filter_factors):
             # we allow the user to provide a single filter factor for multiple
             # filtering windows on a single dimension. This code
             # iterates through each dimension and if a single filter_factor is provided

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -311,7 +311,7 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                        wgts = wgts.T
                    if mode[0] == 'dayenu':
                        if filter2d:
-                           filter_dim_d = [0, 1]
+                           filter_dim_d = [1, 0]
                        else:
                            filter_dim_d = [1]
                        residual, info = dayenu_filter(x=x, data=data, wgts=wgts, filter_dimensions=filter_dim_d,
@@ -328,7 +328,7 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
 
                    elif mode[0] == 'dft' or mode[0] == 'dpss':
                         if filter2d:
-                            filter_dim_d = [0, 1]
+                            filter_dim_d = [1, 0]
                         else:
                             filter_dim_d = [1]
                         model, residual, info = fit_basis_2d(x=x, data=data, filter_centers=filter_centers, filter_dims=filter_dim_d,
@@ -889,8 +889,6 @@ def dayenu_filter(x, data, wgts, filter_dimensions, filter_centers, filter_half_
     data: 1D or 2D (real or complex) numpy array where last dimension is frequency.
     Does not assume that weights have already been multiplied!
     wgts: real numpy array of linear multiplicative weights with the same shape as the data.
-    delta_data: float, list
-        the width of data bins. Typically Hz: float. if 2d clean, should be 2-tuple or 2-list
     filter_dimensions: list
         list of integers indicating data dimensions to filter. Must be 0, 1, or -1
     filter_centers: float, list, or 1d numpy array of delays at which to center filter windows
@@ -974,7 +972,6 @@ def dayenu_filter(x, data, wgts, filter_dimensions, filter_centers, filter_half_
     if not np.all(np.abs(np.asarray(filter_dimensions)) < data.ndim):
         raise ValueError("invalid filter dimensions provided, must be 0 or 1/-1")
     # convert filter dimensions to a list of integers (incase the dimensions were supplied as floats)
-    filter_dimensions=list(np.unique(np.asarray(filter_dimensions)).astype(int))
     # will only filter each dim a single time.
     # now check validity of other inputs. We perform the same check over multiple
     # inputs by iterating over a list with their names.

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -43,6 +43,30 @@ def wedge_width(bl_len, sdf, nchan, standoff=0., horizon=1.):
     bl_dly = horizon * bl_len + standoff
     return calc_width(bl_dly, sdf, nchan)
 
+def _get_filter_area(x, filter_center, filter_width):
+    """
+    Return an 'area' vector demarking where cleaning should be allowed
+    to take place.
+
+    Arguments:
+        x : array-like real space vector listing where data is sampled.
+        filter_center : center of the area to be cleaned. Units of 1/(x-units)
+        filter_width : width of the region of area to be cleaned. Units of 1/(x-units)
+    """
+    nx = len(x)
+    dx = np.mean(np.diff(x))
+    if not np.isinf(filter_width):
+        av = np.ones(len(x))
+        ut, lt = calc_width(filter_width, dx, nx)
+        av[ut:lt] = 0.
+        nc = int(np.round(filter_center * dx * nx))
+        av = np.roll(av, -nc)
+    else:
+        av = np.ones(nx)
+    return av
+
+
+
 def _fourier_filter_hash(filter_centers, filter_half_widths,
                          filter_factors, x, w=None, hash_decimal=10, **kwargs):
     '''
@@ -193,7 +217,7 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                         if filter2d is true, this should be a 2-tuple or 2-list
                         of dictionaries. The dictionary for each dimension must
                         specify the following for each fitting method.
-                        If mode=='dayenu', the user does not need to provide this argument. 
+                        If mode=='dayenu', the user does not need to provide this argument.
                         * 'dft':
                             'fundamental_period': float or 2-tuple
                                 The fundamental_period of dft modes to fit. This is the
@@ -365,7 +389,7 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                             edgecut_hi = [ 0, fitting_options['edgecut_hi'] ]
                             edgecut_low = [ 0, fitting_options['edgecut_low']]
                             filter_centers = [[0.], copy.deepcopy(filter_centers)]
-                            filter_half_widths = [[9e99], copy.deepcopy(filter_half_widths)]
+                            filter_half_widths = [[np.inf], copy.deepcopy(filter_half_widths)]
                             window_opt = ['none', fitting_options['window']]
                         else:
                             if not np.all(np.isclose(np.diff(x[1]), np.mean(np.diff(x[1])))):
@@ -394,18 +418,7 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                         if filt2d_mode == 'rect' or not filter2d:
                             for m in range(2):
                                 for fc, fw in zip(filter_centers[m], filter_half_widths[m]):
-                                    if not fw == 9e99:
-                                        #generate area vector centered at zero
-                                        av = np.ones(len(_x[m]))
-                                        ut, lt = calc_width(fw, np.mean(np.diff(x[m])), len(x[m]))
-                                        av[ut:lt] = 0.
-                                        #cycle area vector based on fc
-                                        nc = int(np.round(fc * np.mean(np.diff(x[m])) * len(x[m])))
-                                        area_vecs[m] = np.roll(av, -nc)
-                                    else:
-                                        area_vecs[m] = np.ones(len(_x[m]))
-                            #if filtering windows are rectangular,
-                            #we can just take outer products
+                                    area_vecs[m] = _get_filter_area(x[m], fc, fw)
                             area = np.outer(area_vecs[0], area_vecs[1])
                         elif filt2d_mode == 'plus' and filter2d:
                             area = np.zeros(data.shape)
@@ -415,28 +428,12 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                                     area_temp = np.zeros(area.shape)
                                     if fc0 >= _x[0].min() and fc0 <= _x[0].max():
                                         #generate area vector centered at zero
-                                        if not fw1 == 9e99:
-                                            av = np.ones(len(_x[1]))
-                                            ut, lt = calc_width(fw1, np.mean(np.diff(x[1])), len(x[1]))
-                                            av[ut:lt] = 0.
-                                            #cycle area vector based on fc
-                                            nc = int(np.round(fc1 * np.mean(np.diff(x[1])) * len(x[1])))
-                                            av = np.roll(av, -nc)
-                                            area_temp[np.argmin(np.abs(_x[0]-fc0)), :] = av
-                                        else:
-                                            area_temp[np.armin(np.abs(_x[0]-fc0)), :] = 1.
+                                        av = _get_filter_area(x[1], fc1, fw1)
+                                        area_temp[np.argmin(np.abs(_x[0]-fc0)), :] = av
                                     if fc1 >= _x[1].min() and fc1 <= _x[1].max():
                                         #generate area vector centered at zero
-                                        if not fw0 == 9e99:
-                                            av = np.ones(len(_x[0]))
-                                            ut, lt = calc_width(fw0, np.mean(np.diff(x[0])), len(x[0]))
-                                            av[ut:lt] = 0.
-                                            #cycle area vector based on fc
-                                            nc = int(np.round(fc0 * np.mean(np.diff(x[0])) * len(x[0])))
-                                            av = np.roll(av, -nc)
-                                            area_temp[:, np.argmin(np.abs(_x[1]-fc1))] = av
-                                        else:
-                                            area_temp[:, np.argmin(np.abs(_x[1]-fc1))] = 1.
+                                        av = _get_filter_area(x[0], fc0, fw0)
+                                        area_temp[:, np.argmin(np.abs(_x[1]-fc1))] = av
                                     area += area_temp
                             area = (area>0.).astype(int)
                         else:
@@ -450,7 +447,6 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                         _d_cl = np.zeros_like(_data)
                         _d_res = np.zeros_like(_data)
                         if not filter2d:
-                            info_clean = {}
                             for i, _d, _w, _a in zip(np.arange(_data.shape[0]).astype(int), _data, _wgts, area):
                                 # we skip steps that might trigger infinite CLEAN loops or divergent behavior.
                                 # if the weights sum up to a value close to zero (most of the data is flagged)

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -390,7 +390,7 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                                         ut, lt = calc_width(fw, np.mean(np.diff(x[m])), len(x[m]))
                                         av[ut:lt] = 0.
                                         #cycle area vector based on fc
-                                        nc = int(np.round(fc * np.mean(np.diff(x[m])), len(x[m])))
+                                        nc = int(np.round(fc * np.mean(np.diff(x[m])) * len(x[m])))
                                         area_vecs[m] = np.roll(av, -nc)
                                     else:
                                         area_vecs[m] = np.ones(len(_x[m]))
@@ -410,7 +410,7 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                                             ut, lt = calc_width(fw1, np.mean(np.diff(x[1])), len(x[1]))
                                             av[ut:lt] = 0.
                                             #cycle area vector based on fc
-                                            nc = int(np.round(fc1 * np.mean(np.diff(x[1])), len(x[1])))
+                                            nc = int(np.round(fc1 * np.mean(np.diff(x[1])) * len(x[1])))
                                             av = np.roll(av, -nc)
                                             area_temp[np.argmin(np.abs(_x[0]-fc0)), :] = av
                                         else:
@@ -422,7 +422,7 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                                             ut, lt = calc_width(fw0, np.mean(np.diff(x[0])), len(x[0]))
                                             av[ut:lt] = 0.
                                             #cycle area vector based on fc
-                                            nc = int(np.round(fc0 * np.mean(np.diff(x[0])), len(x[0])))
+                                            nc = int(np.round(fc0 * np.mean(np.diff(x[0])) * len(x[0])))
                                             av = np.roll(av, -nc)
                                             area_temp[:, np.argmin(np.abs(_x[1]-fc1))] = av
                                         else:

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -384,9 +384,16 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                         if filt2d_mode == 'rect' or not filter2d:
                             for m in range(2):
                                 for fc, fw in zip(filter_centers[m], filter_half_widths[m]):
-                                    # add one fourier bin width to make consistent with get_width
-                                    _dx = np.mean(np.diff(np.fft.fftshift(_x[m])))
-                                    area_vecs[m][np.abs(_x[m] - fc)<=fw + _dx] = 1.
+                                    if not fw == 9e99:
+                                        #generate area vector centered at zero
+                                        av = np.ones(len(_x[m]))
+                                        ut, lt = calc_width(fw, np.mean(np.diff(x[m])), len(x[m]))
+                                        av[ut:lt] = 0.
+                                        #cycle area vector based on fc
+                                        nc = int(np.round(fc * np.mean(np.diff(x[m])), len(x[m])))
+                                        area_vecs[m] = np.roll(av, -nc)
+                                    else:
+                                        area_vecs[m] = np.ones(len(_x[m]))
                             #if filtering windows are rectangular,
                             #we can just take outer products
                             area = np.outer(area_vecs[0], area_vecs[1])
@@ -397,13 +404,29 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                                 for fc1, fw1 in zip(filter_centers[1], filter_half_widths[1]):
                                     area_temp = np.zeros(area.shape)
                                     if fc0 >= _x[0].min() and fc0 <= _x[0].max():
-                                        _dx = np.mean(np.diff(np.fft.fftshift(_x[0])))
-                                        # add one fourier bin width to make consistent with get_width
-                                        area_temp[np.argmin(_x[0]-fc0), np.abs(_x[1] - fc1) <= fw1 + _dx]=1.
+                                        #generate area vector centered at zero
+                                        if not fw1 == 9e99:
+                                            av = np.ones(len(_x[1]))
+                                            ut, lt = calc_width(fw1, np.mean(np.diff(x[1])), len(x[1]))
+                                            av[ut:lt] = 0.
+                                            #cycle area vector based on fc
+                                            nc = int(np.round(fc1 * np.mean(np.diff(x[1])), len(x[1])))
+                                            av = np.roll(av, -nc)
+                                            area_temp[np.argmin(np.abs(_x[0]-fc0)), :] = av
+                                        else:
+                                            area_temp[np.armin(np.abs(_x[0]-fc0)), :] = 1.
                                     if fc1 >= _x[1].min() and fc1 <= _x[1].max():
-                                        _dx = np.mean(np.diff(np.fft.fftshift(_x[1])))
-                                        # add one fourier bin width to make consistent with get_width
-                                        area_temp[np.abs(_x[0] - fc0) <= fw0 + _dx, np.argmin(_x[1]-fc1)]=1.
+                                        #generate area vector centered at zero
+                                        if not fw0 == 9e99:
+                                            av = np.ones(len(_x[0]))
+                                            ut, lt = calc_width(fw0, np.mean(np.diff(x[0])), len(x[0]))
+                                            av[ut:lt] = 0.
+                                            #cycle area vector based on fc
+                                            nc = int(np.round(fc0 * np.mean(np.diff(x[0])), len(x[0])))
+                                            av = np.roll(av, -nc)
+                                            area_temp[:, np.argmin(np.abs(_x[1]-fc1))] = av
+                                        else:
+                                            area_temp[:, np.argmin(np.abs(_x[1]-fc1))] = 1.
                                     area += area_temp
                             area = (area>0.).astype(int)
                         else:

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -384,7 +384,9 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                         if filt2d_mode == 'rect' or not filter2d:
                             for m in range(2):
                                 for fc, fw in zip(filter_centers[m], filter_half_widths[m]):
-                                    area_vecs[m][np.abs(_x[m] - fc)<=fw] = 1.
+                                    # add one fourier bin width to make consistent with get_width
+                                    _dx = np.mean(np.diff(np.fft.fftshift(_x[m])))
+                                    area_vecs[m][np.abs(_x[m] - fc)<=fw + _dx] = 1.
                             #if filtering windows are rectangular,
                             #we can just take outer products
                             area = np.outer(area_vecs[0], area_vecs[1])
@@ -395,9 +397,13 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                                 for fc1, fw1 in zip(filter_centers[1], filter_half_widths[1]):
                                     area_temp = np.zeros(area.shape)
                                     if fc0 >= _x[0].min() and fc0 <= _x[0].max():
-                                        area_temp[np.argmin(np.abs(_x[0]-fc0)),(_x[1] - fc1) <= fw1]=1.
+                                        _dx = np.mean(np.diff(np.fft.fftshift(_x[0])))
+                                        # add one fourier bin width to make consistent with get_width
+                                        area_temp[np.argmin(_x[0]-fc0), np.abs(_x[1] - fc1) <= fw1 + _dx]=1.
                                     if fc1 >= _x[1].min() and fc1 <= _x[1].max():
-                                        area_temp[(_x[0] - fc0) <= fw0, np.argmin(np.abs(_x[1]-fc1))]=1.
+                                        _dx = np.mean(np.diff(np.fft.fftshift(_x[1])))
+                                        # add one fourier bin width to make consistent with get_width
+                                        area_temp[np.abs(_x[0] - fc0) <= fw0 + _dx, np.argmin(_x[1]-fc1)]=1.
                                     area += area_temp
                             area = (area>0.).astype(int)
                         else:
@@ -450,6 +456,12 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                             model = np.fft.fft(_d_cl, axis=1)
                             residual = np.fft.fft(_d_res, axis=1)
                         #transpose back if filtering the 0th dimension.
+                        windmat = np.outer(window[0], window[1])
+                        windmat1 = np.outer(window[0], window[1])
+                        windmat1[np.isclose(windmat1, 0)] = 1.
+                        residual = residual * ~np.isclose(wgts * windmat, 0.0)\
+                                / windmat1
+
                    if not filter2d and filter_dim == 0:
                         model = model.T
                         residual = residual.T

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -463,6 +463,7 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                                     _info['skipped'] = False
                                     del(_info['res'])
                                     info['clean_status']['axis_1'][i] = _info
+                                    info['status']['axis_1'][i] = 'success'
                                 info['filter_params']['axis_1'] = fitting_options
                         elif filter2d:
                                 # we skip 2d cleans if all the data is close to zero (which can cause an infinite clean loop)

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -109,7 +109,7 @@ def calc_width(filter_size, real_delta, nsamples):
     return (uthresh, lthresh)
 
 def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppression_factors,
-                   mode, filter2d, fitting_options, cache=None, filter_dim=1, skip_wgt=0.1,
+                   mode, filter2d, fitting_options=None, cache=None, filter_dim=1, skip_wgt=0.1,
                    max_contiguous_edge_flags=10):
                    '''
                    A filtering function that tries to wrap up all functionality of high_pass_fourier_filter
@@ -193,6 +193,7 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                         if filter2d is true, this should be a 2-tuple or 2-list
                         of dictionaries. The dictionary for each dimension must
                         specify the following for each fitting method.
+                        If mode=='dayenu', the user does not need to provide this argument. 
                         * 'dft':
                             'fundamental_period': float or 2-tuple
                                 The fundamental_period of dft modes to fit. This is the
@@ -290,6 +291,8 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, suppressio
                                                              and values for each key are the status dictionaries returned by aipy.deconv.clean (see aipy.deconv.clean
                                                              for more information).
                    '''
+                   if fitting_options is None and mode != 'dayenu':
+                       raise ValueError("fitting_options can only be None if mode=='dayenu'.")
                    if cache is None:
                        cache = {}
                    supported_modes=['clean', 'dft_leastsq', 'dpss_leastsq', 'dft_matrix', 'dpss_matrix', 'dayenu',

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -630,7 +630,7 @@ def test_fourier_filter():
     dft_options1={'fundamental_period':2.*(times.max()-times.min())}
     dft_options2={'fundamental_period':2.*(times.max()-times.min())}
     dft_options3={'fundamental_period':2.*(dlys.max()-dlys.min())}
-    clean_options1={'tol':1e-6, 'maxiter':100, 'filt2d_mode':'rect',
+    clean_options1={'tol':1e-9, 'maxiter':100, 'filt2d_mode':'rect',
                     'edgecut_low':0, 'edgecut_hi':0, 'add_clean_residual':False,
                     'window':'none', 'gain':0.1, 'alpha':0.5}
     mdl1, res1, info1 = dspec.fourier_filter(x=freqs, data=d, wgts=w, filter_centers=[0.],
@@ -791,7 +791,7 @@ def test_clean_fourier_filter_equality():
     w = (~f).astype(np.float)
     bl_len = 70.0 / 2.99e8
     # here is a fourier filter implementation of clean
-    mdl1, res1, info1 = dspec.fourier_filter(freqs, d, w, [0.], [bl_len - 1./(sdf * len(freqs))], [0.],
+    mdl1, res1, info1 = dspec.fourier_filter(freqs, d, w, [0.], [bl_len], [0.],
                                              mode='clean', filter2d=False, fitting_options={'tol':1e-4})
 
     # here is the vis filter implementation of clean
@@ -806,7 +806,7 @@ def test_clean_fourier_filter_equality():
     # Do the same comparison with more complicated windowing and edge cuts.
     mdl1, res1, info1 = dspec.fourier_filter(freqs, d, w, [0.], [bl_len], [0.],
                                              mode='clean', filter2d=False, fitting_options={'tol':1e-4,
-                                             'window':'tukey', 'edgecut_low':4, 'edgecut_low':4})
+                                             'window':'tukey', 'edgecut_low':4, 'edgecut_hi':4})
     mdl2, res2, info2 = dspec.delay_filter(d, w, bl_len, sdf, standoff=0, horizon=1.0, min_dly=0.0,
                                            edgecut_hi=4, edgecut_low=4, tol=1e-4,
                                            skip_wgt=0.1, gain=0.1, window='tukey')
@@ -817,26 +817,42 @@ def test_clean_fourier_filter_equality():
 
 
     #Do a comparison for time domain clean.
-    mdl1, res1, info1 = dspec.fourier_filter(times, d, w, [0.], [frs[15]], [0.], filter_dim=1,
+    mdl1, res1, info1 = dspec.fourier_filter(times-np.mean(times), d, w, [0.], [frs[15]], [0.], filter_dim=0,
                                              mode='clean', filter2d=False, fitting_options={'tol':1e-4,
-                                             'window':'tukey', 'edgecut_low':4, 'edgecut_low':4})
-    mdl2, res2, info2 = dspec.fringe_filter(d, w, frs[15], dt, edgecut_hi=4, edgecut_low=4,
+                                             'window':'tukey', 'edgecut_low':3, 'edgecut_hi':4})
+    mdl2, res2, info2 = dspec.fringe_filter(d, w, frs[15], dt, edgecut_hi=4, edgecut_low=3,
                                             tol=1e-4, window='tukey', skip_wgt=0.1,
                                             gain=0.1)
     nt.assert_true(np.all(np.isclose(mdl1, mdl2)))
     nt.assert_true(np.all(np.isclose(res1, res2)))
 
-
     #try 2d iterative clean.
-    mdl11, res11, info11 = dspec.fourier_filter(x=[times, freqs], data=d, wgts=w, filter_centers=[[0.],[0.]],
-                                             filter_half_widths=[[fr_len],[bl_len]], suppression_factors=[[0.],[0.]],
-                                             mode='clean', filter2d=True, fitting_options={'filt2d_mode':'rect','tol':1e-5})
-    #try out plus mode. IDK
-    mdl12, res12, info12 = dspec.fourier_filter(x=[times, freqs], data=d, wgts=w, filter_centers=[[0.],[0.]],
-                                             filter_half_widths=[[fr_len],[bl_len]], suppression_factors=[[0.],[0.]],
-                                             mode='clean', filter2d=True, fitting_options={'filt2d_mode':'plus','tol':1e-5})
+    mdl1, res1, info1 = dspec.fourier_filter(x=[times, freqs], data=d, wgts=w, filter_centers=[[0.],[0.]],
+                                             filter_half_widths=[[frs[15]],[bl_len]], suppression_factors=[[0.],[0.]],
+                                             mode='clean', filter2d=True, fitting_options={'filt2d_mode':'rect','tol':1e-5,
+                                             'window':['tukey', 'tukey'], 'add_clean_residual':False})
 
+    mdl2, res2, info2 = dspec.high_pass_fourier_filter(data=d, wgts=w, filter_size=[frs[15], bl_len],
+                                             real_delta=[np.mean(np.diff(times)), np.mean(np.diff(freqs))],
+                                             window='tukey', tol=1e-5, clean2d=True,
+                                             mode='clean', add_clean_residual=False)
 
+    nt.assert_true(np.all(np.isclose(mdl1, mdl2)))
+    nt.assert_true(np.all(np.isclose(res1, res2)))
+
+    #check plus mode.
+    mdl1, res1, info1 = dspec.fourier_filter(x=[times, freqs], data=d, wgts=w, filter_centers=[[0.],[0.]],
+                                             filter_half_widths=[[frs[15]],[bl_len]], suppression_factors=[[0.],[0.]],
+                                             mode='clean', filter2d=True, fitting_options={'filt2d_mode':'plus','tol':1e-5,
+                                             'window':['tukey', 'tukey'], 'add_clean_residual':False})
+
+    mdl2, res2, info2 = dspec.high_pass_fourier_filter(data=d, wgts=w, filter_size=[frs[15], bl_len],
+                                             real_delta=[np.mean(np.diff(times)), np.mean(np.diff(freqs))],
+                                             window='tukey', tol=1e-5, clean2d=True, filt2d_mode='plus',
+                                             mode='clean', add_clean_residual=False)
+
+    nt.assert_true(np.all(np.isclose(mdl1, mdl2)))
+    nt.assert_true(np.all(np.isclose(res1, res2)))
 
 def test_fit_basis_1d():
     #perform dpss interpolation, leastsq

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -802,6 +802,12 @@ def test_clean_fourier_filter_equality():
     nt.assert_true(np.all(np.isclose(mdl1, mdl2)))
     nt.assert_true(np.all(np.isclose(res1, res2)))
 
+    mdl2, res2, info2 = dspec.vis_filter(d, w, bl_len=0., sdf=sdf, standoff=0., horizon=1.0,
+                                         min_dly=bl_len, tol=1e-4, window='none', skip_wgt=0.1, gain=0.1)
+    # validate models and residuals are close.
+    nt.assert_true(np.all(np.isclose(mdl1, mdl2)))
+    nt.assert_true(np.all(np.isclose(res1, res2)))
+
 
     # Do the same comparison with more complicated windowing and edge cuts.
     mdl1, res1, info1 = dspec.fourier_filter(freqs, d, w, [0.], [bl_len], [0.],

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -645,6 +645,10 @@ def test_fourier_filter():
 
     mdl4, res4, info4 = dspec.fourier_filter(freqs, d, w, [0.], [bl_len], [0.], filter2d=False,
                                              mode='clean', fitting_options=clean_options1)
+
+    #check that dayenu can be run without fitting options.
+
+
     clean_options_typo = {'tol':1e-9, 'maxiter':100, 'filt2d_mode':'rect',
                     'edgecut_low':0, 'edgecut_hi':0, 'add_clean_residual':False,
                     'window':'none', 'gain':0.1, 'alphae':0.5}
@@ -657,6 +661,22 @@ def test_fourier_filter():
 
     nt.assert_true(np.all(np.isclose(mdl1, mdl2, atol=1e-6)))
     nt.assert_true(np.all(np.isclose(res1, res2)))
+
+    #check that dayenu can be run without fitting options.
+    mdl3, res3, info3 = dspec.fourier_filter(freqs, d, w, [0.], [bl_len], [1e-9],
+                                             mode='dayenu', filter2d=False, fitting_options={})
+
+    mdl4, res4, info4 = dspec.fourier_filter(freqs, d, w, [0.], [bl_len], [1e-9], filter2d=False,
+                                             mode='dayenu')
+
+    nt.assert_true(np.all(np.isclose(mdl3, mdl4, atol=1e-6)))
+    nt.assert_true(np.all(np.isclose(res3, res4, atol=1e-6)))
+
+    #check value error for providing no fitting options with differet modes
+    for mode in ['dpss_leastsq', 'dft_leastsq', 'clean', 'dayenu_dpss_leastsq']:
+        nt.assert_raises(ValueError, dspec.fourier_filter, freqs, d, w, [0.], [bl_len], [1e-9],
+                         mode=mode, filter2d=False)
+
 
     #check that clean skips if all data is equal to zero, avoids infinite loop case.
     mdl3, res3, info3 = dspec.fourier_filter(freqs, np.zeros_like(d), w, [0.], [bl_len], [0.],

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -661,7 +661,7 @@ def test_fourier_filter():
     #check that clean skips if all data is equal to zero, avoids infinite loop case.
     mdl3, res3, info3 = dspec.fourier_filter(freqs, np.zeros_like(d), w, [0.], [bl_len], [0.],
                                              mode='clean', filter2d=False, fitting_options={})
-    nt.assert_true(np.all([i['skipped'] for i in info3]))
+    nt.assert_true(np.all([info3['status']['axis_1'][i] == 'skipped' for i in info3['status']['axis_1']]))
 
     #check error when unsupported mode provided
     nt.assert_raises(ValueError, dspec.fourier_filter, x=freqs, data=d, wgts=w, filter_centers=[0.],
@@ -757,8 +757,8 @@ def test_fourier_filter():
     mdl13, res13, info13 = dspec.fourier_filter(x=[times, freqs], data=d, wgts=np.zeros_like(w), filter_centers=[[0.],[0.]],
                                              filter_half_widths=[[fr_len],[bl_len]], suppression_factors=[[0.],[0.]],
                                              mode='clean', filter2d=True, fitting_options={'filt2d_mode':'plus','tol':1e-5})
-    nt.assert_true(info13['skipped'])
-
+    nt.assert_true(info13['clean_status']['axis_0']['skipped'])
+    nt.assert_true(info13['clean_status']['axis_1']['skipped'])
     #test error when cleaning with invalid filt2d mode.
     nt.assert_raises(ValueError, dspec.fourier_filter,x=[times, freqs], data=d, wgts=w, filter_centers=[[0.],[0.]],
                                                  filter_half_widths=[[fr_len],[bl_len]], suppression_factors=[[0.],[0.]],


### PR DESCRIPTION
Wrote some unit tests to validate whether cleaning with high_pass_fourier_filter matches up exactly with fourier_filter under identical arguments to address #68. There were some minor differences that I tracked down to the way that fourier_filter calculates the cleaning area that were not precisely the same as how high_pass_fourier filter performs said calculation. After chaning the clean area calculation behavior, the two methods now match up. 

The structure of the info dict returned by `fourier_filter` is now consistent for `clean` between `clean`, `dayenu` and other modes. 