### PR TITLE
Set flagged residuals to zero

### DIFF
--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -828,12 +828,11 @@ def dayenu_filter(x, data, wgts, filter_dimensions, filter_centers, filter_half_
                 info['status']['axis_%d'%fs][sample_num] = 'skipped'
             if return_matrices:
                 filter_matrices[fs][sample_num]=filter_mat
-
+    output[wgts == 0.] = 0.
+    # set residual equal to zero where weights are zero.
     #1d data will only be filtered across "channels".
     if data_1d and ntimes == 1:
         output = output[0]
-    output[wgts == 0.] = 0.
-    # set residual equal to zero where weights are zero.
     return output, info
 
 

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -832,6 +832,8 @@ def dayenu_filter(x, data, wgts, filter_dimensions, filter_centers, filter_half_
     #1d data will only be filtered across "channels".
     if data_1d and ntimes == 1:
         output = output[0]
+    output[wgts == 0.] = 0.
+    # set residual equal to zero where weights are zero.
     return output, info
 
 

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -362,7 +362,6 @@ def test_dayenu_filter():
     #now filter foregrounds and test that std of residuals are close to std of noise:
     filtered_noise, _ =  dspec.dayenu_filter(np.arange(-nf/2, nf/2)*df, data_1d, wghts_1d, [1], filter_centers, filter_half_widths,
                                          filter_factors)
-
     #print(np.std((data_1d - fg_tone).real)*np.sqrt(2.))
     #print(np.std((filtered_noise).real)*np.sqrt(2.))
     np.testing.assert_almost_equal( np.std(filtered_noise.real)**2. + np.std(filtered_noise.imag)**2.,
@@ -370,8 +369,18 @@ def test_dayenu_filter():
     #now filter foregrounds and signal and test that std of residuals are close to std of signal.
     filtered_signal, _ =  dspec.dayenu_filter(np.arange(-nf/2, nf/2)*df, fg_sg, wghts_1d, [1], filter_centers, filter_half_widths,
                                               filter_factors)
+
     np.testing.assert_almost_equal( (np.std(filtered_signal.real)**2. + np.std(filtered_signal.imag)**2.)/1e4,
                                   (np.std(sg_tone.real)**2. + np.std(sg_tone.imag)**2.)/1e4, decimal = 0)
+
+    # check that zeros where wgts are zero.
+    wghts_1d[len(wghts_1d)//4] = 0.
+    wghts_1d[len(wghts_1d)//4 + 5] = 0.
+    filtered_noise, _ =  dspec.dayenu_filter(np.arange(-nf/2, nf/2)*df, data_1d, wghts_1d, [1], filter_centers, filter_half_widths,
+                                            filter_factors)
+    nt.assert_true(np.all(filtered_noise[~(wghts_1d.astype(bool))] == 0.))
+
+
     #Next, we test performing a fringe-rate clean. Generate a 50-meter EW baseline with a single
     #source moving overhead perpindicular to baseline
     TEST_CACHE = {}

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -437,6 +437,17 @@ def test_dayenu_filter():
                                                     filter_half_widths = [[0.001],[100e-9]], filter_factors = [[1e-5],[1e-5]],
                                                     filter_dimensions = [0,1],cache = TEST_CACHE)
 
+    # check for zero residual in flagged regions
+    wgts_2d = np.ones_like(data_2d)
+    wgts_2d[nf // 2+5]  = 0.
+    wgts_2d[:, nf // 4 + 3] = 0.
+    filtered_data_df_fr, _ = dspec.dayenu_filter([np.arange(-nf/2,nf/2)*dt, np.arange(-nf/2,nf/2)*df],
+                                                    data_2d, wgts_2d,
+                                                    filter_centers = [[0.002],[0.]],
+                                                    filter_half_widths = [[0.001],[100e-9]], filter_factors = [[1e-5],[1e-5]],
+                                                    filter_dimensions = [0,1],cache = TEST_CACHE)
+    nt.assert_true(np.all(filtered_data_df_fr[:, nf // 4 + 3] == 0))
+    nt.assert_true(np.all(filtered_data_df_fr[nf // 2 + 5] == 0))
     np.testing.assert_almost_equal(np.sqrt(np.mean(np.abs(filtered_data_df_fr.flatten())**2.)),
                                     1., decimal = 1)
 


### PR DESCRIPTION
small change to `dayenu_filter` that ensures that flagged data in the residual is equal to zero.