### PR TITLE
Handle case when user provides zero or negative filter-half-widths.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION coverage coveralls
   - source activate test-environment
   - conda env update -n test-environment -f environment.yml
-  - pip install pyradiosky
   - pip install git+https://github.com/HERA-Team/hera_sim.git
   - pip install .
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,3 @@ dependencies:
   - pip
   - pip:
     - git+https://github.com/HERA-Team/hera_sim
-    - git+https://github.com/RadioAstronomySoftwareGroup/pyradiosky

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -2089,7 +2089,8 @@ def dpss_operator(x, filter_centers, filter_half_widths, cache=None, eigenval_cu
         if nterms is None:
             nterms = []
             for fn,fw in enumerate(filter_half_widths):
-                dpss_vectors = windows.dpss(nf, nf * df * fw, nf)
+                # also handle case where nf * df * fw >= nf/2.
+                dpss_vectors = windows.dpss(nf, np.min([nf * df * fw, (nf-1)/2.]), nf)
                 if not eigenval_cutoff is None:
                     smat = np.sinc(2 * fw * (xg-yg)) * 2 * df * fw
                     eigvals = np.sum((smat @ dpss_vectors.T) * dpss_vectors.T, axis=0)
@@ -2111,7 +2112,7 @@ def dpss_operator(x, filter_centers, filter_half_widths, cache=None, eigenval_cu
         #next, construct A matrix.
         amat = []
         for fc, fw, nt in zip(filter_centers,filter_half_widths, nterms):
-            amat.append(np.exp(2j * np.pi * (yg[:,:nt]-xc) * fc ) * windows.dpss(nf, nf * df * fw, nt).T )
+            amat.append(np.exp(2j * np.pi * (yg[:,:nt]-xc) * fc ) * windows.dpss(nf, np.min([nf * df * fw, (nt-1)/2.]), nt).T )
         cache[opkey] = ( np.hstack(amat), nterms )
     return cache[opkey]
 

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -443,7 +443,20 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, mode,
                             filter_kwargs['fundamental_period'] = fp[0]
                         else:
                             filter_kwargs['fundamental_period'] = list(fp)
-
+                   # if filter_half_widths are less then zero
+                   # then do not perform any filtering
+                   # by flagging everything.
+                   for fw in filter_half_widths:
+                       if filter2d and np.any(fw <= 0.0):
+                           filter_half_widths=[[1.],[1.]]
+                           wgts=np.zeros_like(wgts)
+                           warn("Filter half-width provided that is less then zero. Skipping.")
+                           break
+                       elif: fw <= 0.0:
+                           filter_half_widths=[1.]
+                           wgts=np.zeros_like(wgts)
+                           warn("Filter half-width provided that is less then zero. Skipping.")
+                           break
                    if mode[0] == 'dayenu':
                        if zero_residual_flags is None:
                            zero_residual_flags = True

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -436,7 +436,9 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, mode,
                                 if np.isnan(fp[m]):
                                     fp[m] = 2. * (x[m].max() - x[m].min())
                         else:
-                            fp = [2. * (x.max() - x.min())]
+                            if np.isnan(fp[0]):
+                                fp = [2. * (x.max() - x.min())]
+
                         if len(fp) == 1:
                             filter_kwargs['fundamental_period'] = fp[0]
                         else:

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -452,7 +452,7 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, mode,
                            wgts=np.zeros_like(wgts)
                            warn("Filter half-width provided that is less then zero. Skipping.")
                            break
-                       elif: fw <= 0.0:
+                       elif fw <= 0.0:
                            filter_half_widths=[1.]
                            wgts=np.zeros_like(wgts)
                            warn("Filter half-width provided that is less then zero. Skipping.")

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -431,9 +431,12 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, mode,
                    _process_filter_kwargs(filter_kwargs, defaults)
                    if 'dft' in mode:
                         fp = np.asarray(filter_kwargs['fundamental_period']).flatten()
-                        for m in range(len(fp)):
-                            if np.isnan(fp[m]):
-                                fp[m] = 2. * (x[m].max() - x[m].min())
+                        if filter2d:
+                            for m in range(len(fp)):
+                                if np.isnan(fp[m]):
+                                    fp[m] = 2. * (x[m].max() - x[m].min())
+                        else:
+                            fp = [2. * (x.max() - x.min())]
                         if len(fp) == 1:
                             filter_kwargs['fundamental_period'] = fp[0]
                         else:


### PR DESCRIPTION
Handle zero or negative filter-half-widths (which can be provided when provided fringe-rate filtering and an autocorrelation is included) by skipping and flagging the entire waterfall. 