### PR TITLE
Modularize pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+omit =
+     */tests/*
+
+[report]
+omit =
+     */tests/*

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -146,7 +146,7 @@ def place_data_on_uniform_grid(x, y, w, xtol=1e-3):
               boolean array indicating which x-values were inserted.
     """
     xdiff = np.diff(x)
-    dx = np.diff(x).min()
+    dx = np.abs(np.diff(x)).min() * np.sign(np.diff(x)[0])
     # first, check whether x, y, w already on a grid.
     # if they are, just return them.
     if np.allclose(xdiff, dx, rtol=0, atol=dx * xtol):
@@ -157,7 +157,7 @@ def place_data_on_uniform_grid(x, y, w, xtol=1e-3):
         return xout, yout, wout, inserted
     # next, check that the array is not on a grid and if it isn't, return x, y, w
     for i in range(len(x) - 1):
-        grid_spacing =  (x[i + 1] - x[i]) / xfundamental
+        grid_spacing =  (x[i + 1] - x[i]) / dx
         integer_spacing = np.round(grid_spacing)
         if not np.isclose(integer_spacing, grid_spacing, rtol=0, atol=xtol):
             xout = x
@@ -166,13 +166,14 @@ def place_data_on_uniform_grid(x, y, w, xtol=1e-3):
             inserted = np.zeros(len(x), dtype=bool)
             return xout, yout, wout, inserted
     # if the array is on a grid, then construct filled in grid.
-    xout = np.linspace(x.min(), x.max(), int(np.round((x.max() - x.min()) / dx)))
+    nx_grid =int(np.round((x[-1] - x[0]) / dx)) + 1
+    xout = np.linspace(x[0], x[-1], nx_grid)
     yout = np.zeros(xout.shape, dtype=np.complex128)
     wout = np.zeros(xout.shape, dtype=np.float)
-    inserted = np.ones(len(x), dtype=bool)
+    inserted = np.ones(len(xout), dtype=bool)
     # fill in original data and weights.
     for x_index, xt in enumerate(x):
-        output_index = np.argmin(np.abs(xout - xt))[0]
+        output_index = np.argmin(np.abs(xout - xt))
         yout[output_index] = y[x_index]
         wout[output_index] = w[x_index]
         inserted[output_index] = False

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -109,6 +109,76 @@ def _get_filter_area(x, filter_center, filter_width):
     return av
 
 
+def place_data_on_uniform_grid(x, y, w, xtol=1e-3):
+    """
+    If possible, place data on a uniformly spaced grid.
+
+    Parameters
+    ----------
+    x: array-like,
+        array of x-values.
+    y: array-like,
+        array of y-values.
+    w: array-like,
+        array of weights.
+    xtol: float, optional.
+        fractional error tolerance to determine if x-values are
+        on an incomplete grid.
+
+    Returns
+    -------
+        xout: array-like
+              If the separations on x are multiples of a single underlying minimum unit
+              returns x with all multiples of the fundamental unit filled in.
+              If x is already uniformly spaced, returns x unchanged. If separations are not
+              multiples of fundamental unit, also returns x unchanged.
+        yout: array-like
+              If the separations on x are multiples of a single underlying minimum unit
+              returns y with all multiples of the fundamental unit filled in with zeros.
+              If x is already uniformly spaced, returns y unchanged. If separations are not
+              multiples of fundamental unit, also returns y unchanged.
+        wout: array-like
+              If the separations on x are multiples of a single underlying minimum unit
+              returns w with all multiples of the fundamental unit filled in with zeros.
+              If x is already uniformly spaced, returns w unchanged. If separations are not
+              multiples of fundamental unit, also returns w unchanged.
+        inserted: array-like
+              boolean array indicating which x-values were inserted.
+    """
+    xdiff = np.diff(x)
+    dx = np.diff(x).min()
+    # first, check whether x, y, w already on a grid.
+    # if they are, just return them.
+    if np.allclose(xdiff, dx, rtol=0, atol=dx * xtol):
+        xout = x
+        yout = y
+        wout = w
+        inserted = np.zeros(len(x), dtype=bool)
+        return xout, yout, wout, inserted
+    # next, check that the array is not on a grid and if it isn't, return x, y, w
+    for i in range(len(x) - 1):
+        grid_spacing =  (x[i + 1] - x[i]) / xfundamental
+        integer_spacing = np.round(grid_spacing)
+        if not np.isclose(integer_spacing, grid_spacing, rtol=0, atol=xtol):
+            xout = x
+            yout = y
+            wout = w
+            inserted = np.zeros(len(x), dtype=bool)
+            return xout, yout, wout, inserted
+    # if the array is on a grid, then construct filled in grid.
+    xout = np.linspace(x.min(), x.max(), int(np.round((x.max() - x.min()) / dx)))
+    yout = np.zeros(xout.shape, dtype=np.complex128)
+    wout = np.zeros(xout.shape, dtype=np.float)
+    inserted = np.ones(len(x), dtype=bool)
+    # fill in original data and weights.
+    for x_index, xt in enumerate(x):
+        output_index = np.argmin(np.abs(xout - xt))[0]
+        yout[output_index] = y[x_index]
+        wout[output_index] = w[x_index]
+        inserted[output_index] = False
+
+    return xout, yout, wout, inserted
+
 
 def _fourier_filter_hash(filter_centers, filter_half_widths,
                          filter_factors, x, w=None, hash_decimal=10, **kwargs):
@@ -1454,7 +1524,7 @@ def delay_filter_leastsq(data, flags, sigma, nmax, add_noise=False,
 
 def _fit_basis_1d(x, y, w, filter_centers, filter_half_widths,
                 basis_options, suppression_factors=None, hash_decimal=10,
-                method='leastsq', basis='dft', cache=None):
+                method='leastsq', basis='dft', build_uniform_grid=True, cache=None):
     """
     A 1d linear-least-squares fitting function for computing models and residuals for fitting of the form
     y_model = A @ c
@@ -1519,7 +1589,13 @@ def _fit_basis_1d(x, y, w, filter_centers, filter_half_widths,
                 using scipy.optimize.leastsq
             *'matrix' derive model by directly calculate the fitting matrix
                 [A^T W A]^{-1} A^T W and applying it to the y vector.
-
+    basis: string, specifying basis to use for interpolation.
+    build_uniform_grid: bool,, optional
+        If True, check if non-uniformities in x are equal to integer multiples of the
+        smallest separation. If so, insert x-values, zero data, and zero weights before filtering.
+        The standard use-case for this is if we are performing fringe-rate filtering on uniformly
+        sampled data but we happen to be missing some observations / integrations because of correlator
+        or librarian dropouts.
 
     Returns:
         model: array-like
@@ -1541,6 +1617,11 @@ def _fit_basis_1d(x, y, w, filter_centers, filter_half_widths,
                   if the method == 'matrix'.
 
     """
+    # fill in missing grid points with zero-weights
+    # and zero data if we have
+    # build_uniform_grid=True.
+    if build_uniform_grid:
+        x, y, w, inserted = place_data_on_uniform_grid(x, y, w)
     if cache is None:
         cache = {}
     info = copy.deepcopy(basis_options)
@@ -1590,6 +1671,11 @@ def _fit_basis_1d(x, y, w, filter_centers, filter_half_widths,
         raise ValueError("Provided 'method', '%s', is not in ['leastsq', 'matrix']."%(method))
     model = amat @ (suppression_vector * cn_out)
     resid = (y - model) * (~np.isclose(w, 0, atol=1e-10)).astype(float) #suppress flagged residuals (such as RFI)
+    # remove inserted grid values.
+    if build_uniform_grid:
+        model = model[~inserted]
+        resid = resid[~inserted]
+
     return model, resid, info
 
 def _clean_filter(x, data, wgts, filter_centers, filter_half_widths,

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -1,7 +1,6 @@
 from .. import dspec
 import numpy as np, random
 import pytest
-import copy
 from pyuvdata import UVData
 from uvtools.data import DATA_PATH
 import os

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -55,8 +55,8 @@ def test_delay_filter_1D():
     data = np.random.normal(size=NCHAN)
     wgts = np.ones_like(data)
     dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=1e-9)
-    assert np.average(data) == pytest.approx(np.average(dmdl), 1e-3)
-    assert np.average(dres) == pytest.approx(0, 1e-3)
+    assert np.allclose(np.average(data), np.average(dmdl), rtol=0, atol=1e-3)
+    assert np.allclose(np.average(dres), 0.0, rtol=0, atol=1e-3)
 
     #check that skip_wgt is properly passed to clean
     wgts[:72] = 0.

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -1052,56 +1052,6 @@ def test_vis_clean():
     assert np.all(np.isclose(res3, res1))
     assert np.all(np.isclose(mdl3, mdl1))
 
-
-def test_place_data_on_uniform_grid():
-    # first, generate uniformly spaced x values and ensure that we get the same thing back.
-    xt = np.arange(0, 100) * 1.23157
-    yt = np.random.randn(len(xt)) + 1j * np.random.randn(len(xt))
-    wt = np.ones(len(xt))
-    for m in range(100):
-        wt[np.random.randint(low=0, high=len(xt), size=20)] = 0.0
-        xout, yout, wout, inserted = dspec.place_data_on_uniform_grid(xt, yt, wt)
-        assert np.allclose(xout, xt)
-        assert np.allclose(yout, yt)
-        assert np.allclose(wout, wt)
-        # remove 10 random grid points and check that
-        # we succisfully reconstruct grid.
-        to_remove = np.random.randint(low=1, high=len(xt)-1, size=10)
-        to_keep = np.array([i for i in range(len(xt)) if i not in to_remove])
-        xtt = xt[to_keep]
-        ytt = yt[to_keep]
-        wtt = wt[to_keep]
-        xout, yout, wout, inserted = dspec.place_data_on_uniform_grid(xtt, ytt, wtt)
-        assert np.allclose(xout, xt)
-        assert np.allclose(yout[to_keep], yt[to_keep])
-        assert np.allclose(yout[to_remove], 0.0)
-        assert np.allclose(wout[to_remove], 0.0)
-        assert np.allclose(wout[to_keep], wt[to_keep])
-
-    # try negative grid.
-    xt = np.arange(0, 100) * -3.8271
-    yt = np.random.randn(len(xt)) + 1j * np.random.randn(len(xt))
-    wt = np.ones(len(xt))
-    for m in range(100):
-        wt[np.random.randint(low=0, high=len(xt), size=20)] = 0.0
-        xout, yout, wout, inserted = dspec.place_data_on_uniform_grid(xt, yt, wt)
-        assert np.allclose(xout, xt)
-        assert np.allclose(yout, yt)
-        assert np.allclose(wout, wt)
-        # remove 10 random grid points and check that
-        # we succisfully reconstruct grid.
-        to_remove = np.random.randint(low=1, high=len(xt)-1, size=10)
-        to_keep = np.array([i for i in range(len(xt)) if i not in to_remove])
-        xtt = xt[to_keep]
-        ytt = yt[to_keep]
-        wtt = wt[to_keep]
-        xout, yout, wout, inserted = dspec.place_data_on_uniform_grid(xtt, ytt, wtt)
-        assert np.allclose(xout, xt)
-        assert np.allclose(yout[to_keep], yt[to_keep])
-        assert np.allclose(yout[to_remove], 0.0)
-        assert np.allclose(wout[to_remove], 0.0)
-        assert np.allclose(wout[to_keep], wt[to_keep])
-
 def test__fit_basis_1d():
     #perform dpss interpolation, leastsq
     fs = np.arange(-50,50)

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -171,7 +171,8 @@ def test_skip_wgt():
     np.testing.assert_allclose(dmdl[0,:], np.zeros_like(dmdl[0,:]), atol=NCHAN*TOL)
     np.testing.assert_allclose(dres[0,:], (data * wgts)[0,:], atol=NCHAN*TOL)
     assert len(info['status']['axis_1']) == NTIMES
-    assert np.all([info['status']['axis_1'][i] == 'skipped' for i in list(info['status']['axis_1'])[::-1]])
+    assert np.all([info['status']['axis_1'][i] == 'skipped' for i in list(info['status']['axis_1'])[:1]])
+    assert not np.any([info['status']['axis_1'][i] == 'skipped' for i in list(info['status']['axis_1'])[1:]])
 
 def test_calc_width():
     # test single filter_size

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -1090,21 +1090,3 @@ def test__fit_basis_1d():
     assert np.all(np.isclose(mod3, mod4, atol=1e-2))
 
     assert np.all(np.isclose((mod2+resid2)*wgts, dw, atol=1e-6))
-    # now remove ten random channels.
-    to_remove = [2, 10, 11, 23, 54, 71, 87, 88, 89, 97]
-    to_keep = np.array([i for i in range(len(fs)) if i not in to_remove])
-
-    mod5, resid5, info5 = dspec._fit_basis_1d(fs[to_keep], dw[to_keep], wgts[to_keep], [0.], [5./50.], basis_options=dft_opts,
-                                    method='leastsq', basis='dft')
-
-    dwt = copy.deepcopy(dw)
-    wgtst = copy.deepcopy(wgts)
-
-    dwt[to_remove] = 0.0
-    wgtst[to_remove] = 0.0
-
-    mod6, resid6, info6 = dspec._fit_basis_1d(fs, dwt, wgtst, [0.], [5./50.], basis_options=dft_opts,
-                                    method='leastsq', basis='dft')
-
-    assert np.allclose(mod5, mod6[to_keep])
-    assert np.allclose(resid5, resid6[to_keep])

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -1,5 +1,4 @@
-import unittest
-import uvtools.dspec as dspec
+from .. import dspec
 import numpy as np, random
 import pytest
 import copy
@@ -10,203 +9,201 @@ import scipy.signal.windows as windows
 import warnings
 random.seed(0)
 
-class TestMethods(unittest.TestCase):
+def test_wedge_width():
+    # Test boundaries of delay bins
+    assert dspec.wedge_width(0, .01, 10) == (1,10)
+    assert dspec.wedge_width(5., .01, 10) == (1,10)
+    assert dspec.wedge_width( 9., .01, 10) == (2,-1)
+    assert dspec.wedge_width(10., .01, 10) == (2,-1)
+    assert dspec.wedge_width(15., .01, 10) == (3,-2)
+    # test nchan
+    assert dspec.wedge_width(10., .01, 20) == (3,-2)
+    assert dspec.wedge_width(10., .01, 40) == (5,-4)
+    # test sdf
+    assert dspec.wedge_width(10., .02, 10) == (3,-2)
+    assert dspec.wedge_width(10., .04, 10) == (5,-4)
+    # test standoff
+    assert dspec.wedge_width(100., .001, 100, standoff=4.) == (11,-10)
+    assert dspec.wedge_width(100., .001, 100, standoff=5.) == (11,-10)
+    assert dspec.wedge_width(100., .001, 100, standoff=10.) == (12,-11)
+    assert dspec.wedge_width(100., .001, 100, standoff=15.) == (13,-12)
+    # test horizon
+    assert dspec.wedge_width(100., .001, 100, horizon=.1) == (2,-1)
+    assert dspec.wedge_width(100., .001, 100, horizon=.5) == (6,-5)
+    assert dspec.wedge_width(100., .001, 100, horizon=1.5) == (16,-15)
+    assert dspec.wedge_width(100., .001, 100, horizon=2.) == (21,-20)
 
-    def test_wedge_width(self):
-        # Test boundaries of delay bins
-        self.assertEqual(dspec.wedge_width(0, .01, 10), (1,10))
-        self.assertEqual(dspec.wedge_width(5., .01, 10), (1,10))
-        self.assertEqual(dspec.wedge_width( 9., .01, 10), (2,-1))
-        self.assertEqual(dspec.wedge_width(10., .01, 10), (2,-1))
-        self.assertEqual(dspec.wedge_width(15., .01, 10), (3,-2))
-        # test nchan
-        self.assertEqual(dspec.wedge_width(10., .01, 20), (3,-2))
-        self.assertEqual(dspec.wedge_width(10., .01, 40), (5,-4))
-        # test sdf
-        self.assertEqual(dspec.wedge_width(10., .02, 10), (3,-2))
-        self.assertEqual(dspec.wedge_width(10., .04, 10), (5,-4))
-        # test standoff
-        self.assertEqual(dspec.wedge_width(100., .001, 100, standoff=4.), (11,-10))
-        self.assertEqual(dspec.wedge_width(100., .001, 100, standoff=5.), (11,-10))
-        self.assertEqual(dspec.wedge_width(100., .001, 100, standoff=10.), (12,-11))
-        self.assertEqual(dspec.wedge_width(100., .001, 100, standoff=15.), (13,-12))
-        # test horizon
-        self.assertEqual(dspec.wedge_width(100., .001, 100, horizon=.1), (2,-1))
-        self.assertEqual(dspec.wedge_width(100., .001, 100, horizon=.5), (6,-5))
-        self.assertEqual(dspec.wedge_width(100., .001, 100, horizon=1.5), (16,-15))
-        self.assertEqual(dspec.wedge_width(100., .001, 100, horizon=2.), (21,-20))
+def test_delay_filter_dims():
+    pytest.raises(ValueError, dspec.delay_filter, np.zeros((1,2,3)), np.zeros((1,2,3)), 0, .001)
 
-    def test_delay_filter_dims(self):
-        self.assertRaises(ValueError, dspec.delay_filter, np.zeros((1,2,3)), np.zeros((1,2,3)), 0, .001)
+def test_delay_filter_1D():
+    NCHAN = 128
+    TOL = 1e-6
+    data = np.ones(NCHAN, dtype=np.complex)
+    wgts = .5*np.ones(NCHAN, dtype=np.complex)
+    dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
+    np.testing.assert_allclose(data, dmdl, atol=NCHAN*TOL)
+    np.testing.assert_allclose(dres, np.zeros_like(dres), atol=NCHAN*TOL)
+    wgts[::16] = 0
+    # This test should have been failing since _w = 0.46 but skip_wgt=0.5 by default for delay_filter.
+    # The reason it was not failing originally was because no 1d check for skip_wgt existed in high_pass_fourier_filter.
+    # This check does exist in fourier_filter (as it should) and now the test, in its original form, fails.
+    # I've changed the skip_wgt to 0.1 (down from 0.5) so that it passes.
+    dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL, skip_wgt=0.1)
+    np.testing.assert_allclose(data, dmdl, atol=NCHAN*TOL)
+    np.testing.assert_allclose(dres, np.zeros_like(dres), atol=NCHAN*TOL)
+    data = np.random.normal(size=NCHAN)
+    wgts = np.ones_like(data)
+    dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=1e-9)
+    assert np.average(data) == pytest.approx(np.average(dmdl), 1e-3)
+    assert np.average(dres) == pytest.approx(0, 1e-3)
 
-    def test_delay_filter_1D(self):
-        NCHAN = 128
-        TOL = 1e-6
-        data = np.ones(NCHAN, dtype=np.complex)
-        wgts = .5*np.ones(NCHAN, dtype=np.complex)
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
-        np.testing.assert_allclose(data, dmdl, atol=NCHAN*TOL)
-        np.testing.assert_allclose(dres, np.zeros_like(dres), atol=NCHAN*TOL)
-        wgts[::16] = 0
-        # This test should have been failing since _w = 0.46 but skip_wgt=0.5 by default for delay_filter.
-        # The reason it was not failing originally was because no 1d check for skip_wgt existed in high_pass_fourier_filter.
-        # This check does exist in fourier_filter (as it should) and now the test, in its original form, fails.
-        # I've changed the skip_wgt to 0.1 (down from 0.5) so that it passes.
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL, skip_wgt=0.1)
-        np.testing.assert_allclose(data, dmdl, atol=NCHAN*TOL)
-        np.testing.assert_allclose(dres, np.zeros_like(dres), atol=NCHAN*TOL)
-        data = np.random.normal(size=NCHAN)
-        wgts = np.ones_like(data)
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=1e-9)
-        self.assertAlmostEqual(np.average(data), np.average(dmdl), 3)
-        self.assertAlmostEqual(np.average(dres), 0, 3)
+    #check that skip_wgt is properly passed to clean
+    wgts[:72] = 0.
+    dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL, skip_wgt=0.5, mode='clean')
+    assert info['status']['axis_1'][0] == 'skipped'
 
-        #check that skip_wgt is properly passed to clean
-        wgts[:72] = 0.
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL, skip_wgt=0.5, mode='clean')
-        assert info['status']['axis_1'][0] == 'skipped'
+def test_delay_filter_2D():
+    NCHAN = 128
+    NTIMES = 10
+    TOL = 1e-6
+    data = np.ones((NTIMES, NCHAN), dtype=np.complex)
+    wgts = np.ones((NTIMES, NCHAN), dtype=np.complex)
+    dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
+    np.testing.assert_allclose(data, dmdl, atol=NCHAN*TOL)
+    np.testing.assert_allclose(dres, np.zeros_like(dres), atol=NCHAN*TOL)
+    wgts[:,::16] = 0;
+    wgts*=.9 #tests to make sure wgts**2 normalization works
+    dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
+    np.testing.assert_allclose(data, dmdl, atol=NCHAN*TOL)
+    np.testing.assert_allclose(dres, np.zeros_like(dres), atol=NCHAN*TOL)
+    data = np.array(np.random.normal(size=(NTIMES,NCHAN)),dtype=complex)
+    wgts = np.ones_like(data)
+    dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=1e-9)
+    np.testing.assert_allclose(np.average(data,axis=1), np.average(dmdl,axis=1), atol=1e-3)
+    np.testing.assert_allclose(np.average(dres,axis=1), 0, atol=1e-3)
+    #check that skip_wgt is properly passed to clean
+    wgts[0,:72] = 0.
+    dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL, skip_wgt=0.5, mode='clean')
+    assert info['status']['axis_1'][0] == 'skipped'
+    assert info['status']['axis_1'][1] == 'success'
 
-    def test_delay_filter_2D(self):
-        NCHAN = 128
-        NTIMES = 10
-        TOL = 1e-6
-        data = np.ones((NTIMES, NCHAN), dtype=np.complex)
-        wgts = np.ones((NTIMES, NCHAN), dtype=np.complex)
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
-        np.testing.assert_allclose(data, dmdl, atol=NCHAN*TOL)
-        np.testing.assert_allclose(dres, np.zeros_like(dres), atol=NCHAN*TOL)
-        wgts[:,::16] = 0;
-        wgts*=.9 #tests to make sure wgts**2 normalization works
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
-        np.testing.assert_allclose(data, dmdl, atol=NCHAN*TOL)
-        np.testing.assert_allclose(dres, np.zeros_like(dres), atol=NCHAN*TOL)
-        data = np.array(np.random.normal(size=(NTIMES,NCHAN)),dtype=complex)
-        wgts = np.ones_like(data)
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=1e-9)
-        np.testing.assert_allclose(np.average(data,axis=1), np.average(dmdl,axis=1), atol=1e-3)
-        np.testing.assert_allclose(np.average(dres,axis=1), 0, atol=1e-3)
-        #check that skip_wgt is properly passed to clean
-        wgts[0,:72] = 0.
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL, skip_wgt=0.5, mode='clean')
-        assert info['status']['axis_1'][0] == 'skipped'
-        assert info['status']['axis_1'][1] == 'success'
+def test_fourier_model():
+    NMAX = 7
+    NFREQS = 100
+    nmodes = 2*NMAX + 1
+    cn = (np.arange(nmodes) + 1.j*np.arange(nmodes)) / float(nmodes)
+    model = dspec.fourier_model(cn, NFREQS)
 
-    def test_fourier_model(self):
-        NMAX = 7
-        NFREQS = 100
-        nmodes = 2*NMAX + 1
-        cn = (np.arange(nmodes) + 1.j*np.arange(nmodes)) / float(nmodes)
-        model = dspec.fourier_model(cn, NFREQS)
+    # Test shape of output model
+    assert (NFREQS,) == model.shape
 
-        # Test shape of output model
-        self.assertEqual((NFREQS,), model.shape)
+    # Test errors
+    pytest.raises(ValueError, dspec.fourier_model, 3, NFREQS)
+    pytest.raises(ValueError, dspec.fourier_model, np.empty((3, 3)), NFREQS)
 
-        # Test errors
-        pytest.raises(ValueError, dspec.fourier_model, 3, NFREQS)
-        pytest.raises(ValueError, dspec.fourier_model, np.empty((3, 3)), NFREQS)
+def test_delay_filter_leastsq():
+    NCHAN = 128
+    NTIMES = 10
+    TOL = 1e-7
+    data = np.ones((NTIMES, NCHAN), dtype=np.complex)
+    flags = np.zeros((NTIMES, NCHAN), dtype=np.bool)
+    sigma = 0.1 # Noise level (not important here)
 
-    def test_delay_filter_leastsq(self):
-        NCHAN = 128
-        NTIMES = 10
-        TOL = 1e-7
-        data = np.ones((NTIMES, NCHAN), dtype=np.complex)
-        flags = np.zeros((NTIMES, NCHAN), dtype=np.bool)
-        sigma = 0.1 # Noise level (not important here)
+    # Fourier coeffs for input data, ordered from (-nmax, nmax)
+    cn = np.array([-0.1-0.1j, -0.1+0.1j, -0.3-0.01j, 0.5+0.01j,
+                   -0.3-0.01j, -0.1+0.1j, 0.1-0.1j])
+    data *= np.atleast_2d( dspec.fourier_model(cn, NCHAN) )
 
-        # Fourier coeffs for input data, ordered from (-nmax, nmax)
-        cn = np.array([-0.1-0.1j, -0.1+0.1j, -0.3-0.01j, 0.5+0.01j,
-                       -0.3-0.01j, -0.1+0.1j, 0.1-0.1j])
-        data *= np.atleast_2d( dspec.fourier_model(cn, NCHAN) )
+    # Estimate smooth Fourier model on unflagged data
+    bf_model, cn_out, data_out = dspec.delay_filter_leastsq(data, flags,
+                                                            sigma, nmax=3,
+                                                            add_noise=False)
+    np.testing.assert_allclose(data, bf_model, atol=NCHAN*TOL)
+    np.testing.assert_allclose(cn, cn_out[0], atol=1e-6)
 
-        # Estimate smooth Fourier model on unflagged data
-        bf_model, cn_out, data_out = dspec.delay_filter_leastsq(data, flags,
-                                                                sigma, nmax=3,
-                                                                add_noise=False)
-        np.testing.assert_allclose(data, bf_model, atol=NCHAN*TOL)
-        np.testing.assert_allclose(cn, cn_out[0], atol=1e-6)
+    # Estimate smooth Fourier model on data with some flags
+    flags[:,10] = True
+    flags[:,65:70] = True
+    bf_model, cn_out, data_out = dspec.delay_filter_leastsq(data, flags,
+                                                            sigma, nmax=3,
+                                                            add_noise=False)
+    np.testing.assert_allclose(data, bf_model, atol=NCHAN*TOL)
+    np.testing.assert_allclose(data, data_out, atol=NCHAN*TOL)
 
-        # Estimate smooth Fourier model on data with some flags
-        flags[:,10] = True
-        flags[:,65:70] = True
-        bf_model, cn_out, data_out = dspec.delay_filter_leastsq(data, flags,
-                                                                sigma, nmax=3,
-                                                                add_noise=False)
-        np.testing.assert_allclose(data, bf_model, atol=NCHAN*TOL)
-        np.testing.assert_allclose(data, data_out, atol=NCHAN*TOL)
+    # Test 1D code directly
+    bf_model, cn_out, data_out = dspec.delay_filter_leastsq_1d(
+        data[0], flags[0], sigma, nmax=3, add_noise=False)
+    np.testing.assert_allclose(data[0], bf_model, atol=NCHAN*TOL)
 
-        # Test 1D code directly
-        bf_model, cn_out, data_out = dspec.delay_filter_leastsq_1d(
-            data[0], flags[0], sigma, nmax=3, add_noise=False)
-        np.testing.assert_allclose(data[0], bf_model, atol=NCHAN*TOL)
+    # Test 1D code with non-linear leastsq
+    bf_model, cn_out, data_out = dspec.delay_filter_leastsq_1d(
+        data[0], flags[0], sigma, nmax=3, add_noise=False, use_linear=False)
+    np.testing.assert_allclose(data[0], bf_model, atol=NCHAN*TOL)
 
-        # Test 1D code with non-linear leastsq
-        bf_model, cn_out, data_out = dspec.delay_filter_leastsq_1d(
-            data[0], flags[0], sigma, nmax=3, add_noise=False, use_linear=False)
-        np.testing.assert_allclose(data[0], bf_model, atol=NCHAN*TOL)
+    # Test that noise injection can be switched on
+    bf_model, cn_out, data_out = dspec.delay_filter_leastsq_1d(
+        data[0], flags[0], sigma, nmax=3, add_noise=True)
+    np.testing.assert_allclose(data[0], bf_model, atol=NCHAN * TOL * sigma)
 
-        # Test that noise injection can be switched on
-        bf_model, cn_out, data_out = dspec.delay_filter_leastsq_1d(
-            data[0], flags[0], sigma, nmax=3, add_noise=True)
-        np.testing.assert_allclose(data[0], bf_model, atol=NCHAN * TOL * sigma)
+    # Test with a noise array
+    sigma_array = sigma * np.ones_like(data[0])
+    bf_model, cn_out, data_out = dspec.delay_filter_leastsq_1d(
+        data[0], flags[0], sigma_array, nmax=3, add_noise=True)
+    np.testing.assert_allclose(data[0], bf_model, atol=NCHAN * TOL * sigma)
 
-        # Test with a noise array
-        sigma_array = sigma * np.ones_like(data[0])
-        bf_model, cn_out, data_out = dspec.delay_filter_leastsq_1d(
-            data[0], flags[0], sigma_array, nmax=3, add_noise=True)
-        np.testing.assert_allclose(data[0], bf_model, atol=NCHAN * TOL * sigma)
+    # Test errors
+    pytest.raises(ValueError, dspec.delay_filter_leastsq_1d,
+                     data[0], flags[0], sigma, nmax=3, operator=np.empty((3, 3)))
+    pytest.raises(ValueError, dspec.delay_filter_leastsq_1d,
+                     data[0], flags[0], sigma, nmax=3, cn_guess=np.array([3]))
 
-        # Test errors
-        pytest.raises(ValueError, dspec.delay_filter_leastsq_1d,
-                         data[0], flags[0], sigma, nmax=3, operator=np.empty((3, 3)))
-        pytest.raises(ValueError, dspec.delay_filter_leastsq_1d,
-                         data[0], flags[0], sigma, nmax=3, cn_guess=np.array([3]))
+def test_skip_wgt():
+    NCHAN = 128
+    NTIMES = 10
+    TOL = 1e-6
+    data = np.ones((NTIMES, NCHAN), dtype=np.complex)
+    wgts = np.ones((NTIMES, NCHAN), dtype=np.complex)
+    wgts[0, 0:-4] = 0
+    dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL, skip_wgt=.1)
+    np.testing.assert_allclose(data[1:,:], dmdl[1:,:], atol=NCHAN*TOL)
+    np.testing.assert_allclose(dres[1:,:], np.zeros_like(dres)[1:,:], atol=NCHAN*TOL)
+    np.testing.assert_allclose(dmdl[0,:], np.zeros_like(dmdl[0,:]), atol=NCHAN*TOL)
+    np.testing.assert_allclose(dres[0,:], (data * wgts)[0,:], atol=NCHAN*TOL)
+    assert len(info['status']['axis_1']) == NTIMES
+    assert np.all([info['status']['axis_1'][i] == 'skipped' for i in list(info['status']['axis_1'])[::-1]])
 
-    def test_skip_wgt(self):
-        NCHAN = 128
-        NTIMES = 10
-        TOL = 1e-6
-        data = np.ones((NTIMES, NCHAN), dtype=np.complex)
-        wgts = np.ones((NTIMES, NCHAN), dtype=np.complex)
-        wgts[0, 0:-4] = 0
-        dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL, skip_wgt=.1)
-        np.testing.assert_allclose(data[1:,:], dmdl[1:,:], atol=NCHAN*TOL)
-        np.testing.assert_allclose(dres[1:,:], np.zeros_like(dres)[1:,:], atol=NCHAN*TOL)
-        np.testing.assert_allclose(dmdl[0,:], np.zeros_like(dmdl[0,:]), atol=NCHAN*TOL)
-        np.testing.assert_allclose(dres[0,:], (data * wgts)[0,:], atol=NCHAN*TOL)
-        self.assertEqual(len(info['status']['axis_1']), NTIMES)
-        self.assertTrue(info['status']['axis_1'][i] == 'skipped' for i in list(info['status']['axis_1'])[::-1])
+def test_calc_width():
+    # test single filter_size
+    nchan = 100
+    dt = 10.
+    filter_size = 1e-2
+    u, l = dspec.calc_width(filter_size, dt, nchan)
+    frs = np.fft.fftfreq(nchan, dt)  # negative b/c of ifft convention
+    assert np.all(np.abs(frs[u:l]) > filter_size)
 
-    def test_calc_width(self):
-        # test single filter_size
-        nchan = 100
-        dt = 10.
-        filter_size = 1e-2
-        u, l = dspec.calc_width(filter_size, dt, nchan)
-        frs = np.fft.fftfreq(nchan, dt)  # negative b/c of ifft convention
-        assert np.all(np.abs(frs[u:l]) > filter_size)
+    # test multiple entries in filter_size
+    filter_size = (1e-2, 2e-2)
+    u, l = dspec.calc_width(filter_size, dt, nchan)
+    assert np.all((frs[u:l] < -1e-2) | (frs[u:l] > 2e-2))
 
-        # test multiple entries in filter_size
-        filter_size = (1e-2, 2e-2)
-        u, l = dspec.calc_width(filter_size, dt, nchan)
-        assert np.all((frs[u:l] < -1e-2) | (frs[u:l] > 2e-2))
+def test_gen_window():
+    for w in ['none', 'blackmanharris', 'hann', 'tukey', 'barthann', 'blackmanharris-7term',
+              'cosinesum-9term', 'cosinesum-11term']:
+        win = dspec.gen_window(w, 100)
+        assert len(win) == 100
+        assert isinstance(win, np.ndarray)
+        assert win.min() >= 0.0
+        assert win.max() <= 1.0
+        pytest.raises(ValueError, dspec.gen_window, w, 100, normalization='foo')
+        win2 = dspec.gen_window(w, 100,normalization='mean')
+        assert np.all(np.isclose(win, win2*np.mean(win),atol=1e-6))
+        win3 = dspec.gen_window(w, 100,normalization='rms')
+        assert np.all(np.isclose(win, win3*np.sqrt(np.mean(win**2.)),atol=1e-6))
 
-    def test_gen_window(self):
-        for w in ['none', 'blackmanharris', 'hann', 'tukey', 'barthann', 'blackmanharris-7term',
-                  'cosinesum-9term', 'cosinesum-11term']:
-            win = dspec.gen_window(w, 100)
-            assert len(win) == 100
-            assert isinstance(win, np.ndarray)
-            assert win.min() >= 0.0
-            assert win.max() <= 1.0
-            pytest.raises(ValueError, dspec.gen_window, w, 100, normalization='foo')
-            win2 = dspec.gen_window(w, 100,normalization='mean')
-            assert np.all(np.isclose(win, win2*np.mean(win),atol=1e-6))
-            win3 = dspec.gen_window(w, 100,normalization='rms')
-            assert np.all(np.isclose(win, win3*np.sqrt(np.mean(win**2.)),atol=1e-6))
-
-        pytest.raises(ValueError, dspec.gen_window, 'foo', 200)
-        # check Ncut ValueError
-        pytest.raises(ValueError, dspec.gen_window, 'bh', 200, edgecut_hi=101, edgecut_low=100)
+    pytest.raises(ValueError, dspec.gen_window, 'foo', 200)
+    # check Ncut ValueError
+    pytest.raises(ValueError, dspec.gen_window, 'bh', 200, edgecut_hi=101, edgecut_low=100)
 
 
 def test_dft_operator():
@@ -1160,6 +1157,3 @@ def test__fit_basis_1d():
 
     assert np.allclose(mod5, mod6[to_keep])
     assert np.allclose(resid5, resid6[to_keep])
-
-if __name__ == '__main__':
-    unittest.main()

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -1080,6 +1080,29 @@ def test_place_data_on_uniform_grid():
         assert np.allclose(wout[to_remove], 0.0)
         assert np.allclose(wout[to_keep], wt[to_keep])
 
+    # try negative grid.
+    xt = np.arange(0, 100) * -3.8271
+    yt = np.random.randn(len(xt)) + 1j * np.random.randn(len(xt))
+    wt = np.ones(len(xt))
+    for m in range(100):
+        wt[np.random.randint(low=0, high=len(xt), size=20)] = 0.0
+        xout, yout, wout, inserted = dspec.place_data_on_uniform_grid(xt, yt, wt)
+        assert np.allclose(xout, xt)
+        assert np.allclose(yout, yt)
+        assert np.allclose(wout, wt)
+        # remove 10 random grid points and check that
+        # we succisfully reconstruct grid.
+        to_remove = np.random.randint(low=1, high=len(xt)-1, size=10)
+        to_keep = np.array([i for i in range(len(xt)) if i not in to_remove])
+        xtt = xt[to_keep]
+        ytt = yt[to_keep]
+        wtt = wt[to_keep]
+        xout, yout, wout, inserted = dspec.place_data_on_uniform_grid(xtt, ytt, wtt)
+        assert np.allclose(xout, xt)
+        assert np.allclose(yout[to_keep], yt[to_keep])
+        assert np.allclose(yout[to_remove], 0.0)
+        assert np.allclose(wout[to_remove], 0.0)
+        assert np.allclose(wout[to_keep], wt[to_keep])
 
 def test__fit_basis_1d():
     #perform dpss interpolation, leastsq

--- a/uvtools/tests/test_plot.py
+++ b/uvtools/tests/test_plot.py
@@ -43,16 +43,16 @@ def axes_contains(ax, obj_list):
     def test_data_mode(self):
         data = np.ones(100) - 1j*np.ones(100)
         d = plot.data_mode(data, mode='abs')
-        self.assertTrue(np.all(d == np.sqrt(2)))
+        assert np.all(d == np.sqrt(2))
         d = plot.data_mode(data, mode='log')
-        self.assertTrue(np.all(d == np.log10(np.sqrt(2))))
+        assert np.all(d == np.log10(np.sqrt(2)))
         d = plot.data_mode(data, mode='phs')
-        self.assertTrue(np.all(d == -np.pi/4))
+        assert np.all(d == -np.pi/4)
         d = plot.data_mode(data, mode='real')
-        self.assertTrue(np.all(d == 1))
+        assert np.all(d == 1)
         d = plot.data_mode(data, mode='imag')
-        self.assertTrue(np.all(d == -1))
-        self.assertRaises(ValueError, plot.data_mode, data, mode='')
+        assert np.all(d == -1)
+        pytest.raises(ValueError, plot.data_mode, data, mode='')
 
     def test_waterfall(self):
         import matplotlib
@@ -386,7 +386,7 @@ class TestDiffPlotters():
                 )
 
                 # check the number of plots is correct
-                self.assertTrue(axes_contains(fig, elements))
+                assert axes_contains(fig, elements)
 
                 # check that the plots are labeled correctly
                 for i, ax in enumerate(fig.axes):
@@ -405,7 +405,7 @@ class TestDiffPlotters():
                     dim = "lst" if dim == "time" else dim
 
                     # make sure that the label is correct
-                    self.assertTrue(xlabel.startswith(dim))
+                    assert xlabel.startswith(dim)
 
         plt.close(fig)
 
@@ -419,7 +419,7 @@ class TestDiffPlotters():
         # make sure that it's plotting in frequency space
         ax = fig.axes[0]
         xlabel = ax.get_xlabel().lower()
-        self.assertTrue(xlabel.startswith('freq'))
+        assert xlabel.startswith('freq')
 
         # check that it works when an axis has length 1
         fig = plot.plot_diff_1d(
@@ -435,7 +435,7 @@ class TestDiffPlotters():
         # check for six instances of subplots, one per image and
         # one per colorbar
         elements = [(plt.Subplot, 6),]
-        self.assertTrue(axes_contains(fig, elements))
+        assert axes_contains(fig, elements)
 
         # now check that we get three images and three colorbars
         Nimages = 0
@@ -445,12 +445,12 @@ class TestDiffPlotters():
             cbar = [(matplotlib.collections.QuadMesh, 1),]
             contains_image = axes_contains(ax, image)
             contains_cbar = axes_contains(ax, cbar)
-            self.assertTrue(contains_image or contains_cbar)
+            assert contains_image or contains_cbar
             Nimages += int(contains_image)
             Ncbars += int(contains_cbar)
 
-        self.assertTrue(Nimages == 3)
-        self.assertTrue(Ncbars == 3)
+        assert Nimages == 3
+        assert Ncbars == 3
 
         # close the figure
         plt.close(fig)
@@ -487,7 +487,7 @@ class TestDiffPlotters():
                                                plot_type=plot_type)
 
             # check that the correct number of subplots are made
-            self.assertTrue(axes_contains(fig, elements))
+            assert axes_contains(fig, elements)
 
             Nimages = 0
             Ncbars = 0
@@ -500,11 +500,11 @@ class TestDiffPlotters():
                 contains_cbar = axes_contains(ax, cbar)
                 Nimages += int(contains_image)
                 Ncbars += int(contains_cbar)
-                self.assertTrue(contains_image or contains_cbar)
+                assert contains_image or contains_cbar
 
             # check that the amount of colorbars and images is correct
-            self.assertTrue(Nimages == Nplots)
-            self.assertTrue(Ncbars == Nplots)
+            assert Nimages == Nplots
+            assert Ncbars == Nplots
 
             # now close the figure
             plt.close(fig)

--- a/uvtools/tests/test_plot.py
+++ b/uvtools/tests/test_plot.py
@@ -82,10 +82,8 @@ class TestFancyPlotters():
     def tearDown(self):
         pass
 
-    def runTest(self):
-        pass
-
     def test_labeled_waterfall(self):
+        self.setUp()
         # Most of this functionality is tested in the next test function,
         # so this will test some features not exposed in
         # plot.fourier_transform_waterfalls
@@ -123,8 +121,10 @@ class TestFancyPlotters():
         )
         image = ax.get_images()[0]
         assert np.allclose(image.get_clim(), (-6, -5))
+        self.tearDown()
 
     def test_fourier_transform_waterfalls(self):
+        self.setUp()
         uvd = self.uvd
         data = uvd.get_data(0,1,'xx')
         freqs = np.unique(uvd.freq_array) # Hz
@@ -263,9 +263,9 @@ class TestFancyPlotters():
 
         with pytest.raises(TypeError):
             plot.fourier_transform_waterfalls(data=np.ones((15,20), dtype=np.float))
+        self.tearDown()
 
-
-class TestDiffPlotters(unittest.TestCase):
+class TestDiffPlotters():
 
     def setUp(self):
         # make some mock data
@@ -368,10 +368,8 @@ class TestDiffPlotters(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def runTest(self):
-        pass
-
     def test_plot_diff_1d(self):
+        self.setUp()
         # list possible plot types and dimensions
         plot_types = ("normal", "fourier", "both")
         dimensions = ("time", "freq")
@@ -428,8 +426,10 @@ class TestDiffPlotters(unittest.TestCase):
                 self.uvd_1d_freqs, self.uvd_1d_freqs, self.antpairpol,
                 plot_type="normal"
         )
+        self.tearDown()
 
     def test_plot_diff_uv(self):
+        self.setUp()
         # plot something
         fig = plot.plot_diff_uv(self.uvd1, self.uvd2)
         # check for six instances of subplots, one per image and
@@ -454,9 +454,11 @@ class TestDiffPlotters(unittest.TestCase):
 
         # close the figure
         plt.close(fig)
+        self.tearDown()
 
 
     def test_plot_diff_waterfall(self):
+        self.setUp()
         plot_types = ("time_vs_freq", "time_vs_dly",
                       "fr_vs_freq", "fr_vs_dly")
         # get all combinations
@@ -506,8 +508,10 @@ class TestDiffPlotters(unittest.TestCase):
 
             # now close the figure
             plt.close(fig)
+            self.tearDown()
 
     def test_plot_diff_waterfall_with_tapers(self):
+        self.setUp()
         # since the above test makes sure the figures are correctly configured,
         # this one will just make sure nothing breaks when a taper is specified
         fig = plot.plot_diff_waterfall(
@@ -516,8 +520,10 @@ class TestDiffPlotters(unittest.TestCase):
         )
 
         plt.close(fig)
+        self.tearDown()
 
     def test_check_metadata(self):
+        self.setUp()
         for attr, value in self.__dict__.items():
             if attr.startswith("uvd_1d"):
                 utils.check_uvd_pair_metadata(value, value)
@@ -528,7 +534,4 @@ class TestDiffPlotters(unittest.TestCase):
                           plot.plot_diff_uv,
                           self.uvd1, value,
                           check_metadata=True)
-
-
-if __name__ == '__main__':
-    unittest.main()
+        self.tearDown()

--- a/uvtools/tests/test_utils.py
+++ b/uvtools/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
-import uvtools as uvt
 import numpy as np
+from .. import utils
 import glob
 import os
 import sys
@@ -22,7 +22,7 @@ def test_search_data():
     templates = sorted(files + ["zen.inp.{pol}.uv"])
 
     # search data
-    dfs, dps = uvt.utils.search_data(templates, pols)
+    dfs, dps = utils.search_data(templates, pols)
     assert len(dfs) ==  2
     assert len(dfs[0]) ==  len(dfs[1])
     assert len(dfs[1]) ==  2
@@ -33,23 +33,23 @@ def test_search_data():
     assert np.all(['.xx.' in df for df in dfs[0]])
 
     # matched pols
-    dfs, dps = uvt.utils.search_data(templates, pols, matched_pols=True)
+    dfs, dps = utils.search_data(templates, pols, matched_pols=True)
     assert len(dfs) ==  2
     assert len(dfs[0]) ==  len(dfs[1])
     assert len(dfs[0]) ==  2
     assert np.all(['.xx.' in df for df in dfs[0]])
-    dfs, dps = uvt.utils.search_data(files, pols + ['pI'], matched_pols=True)
+    dfs, dps = utils.search_data(files, pols + ['pI'], matched_pols=True)
     assert len(dfs) ==  0
 
     # reverse nesting
-    dfs, dps = uvt.utils.search_data(templates, pols, reverse_nesting=True)
+    dfs, dps = utils.search_data(templates, pols, reverse_nesting=True)
     assert len(dfs) ==  2
     assert len(dfs[0]) ==  len(dfs[1])
     assert len(dfs[1]) ==  2
     assert np.all(['.bar.' in df for df in dfs[0]])
 
     # flatten
-    dfs, dps = uvt.utils.search_data(templates, pols, flatten=True)
+    dfs, dps = utils.search_data(templates, pols, flatten=True)
     assert len(dfs) == 4
     assert isinstance(dfs[0], (str, np.str))
 


### PR DESCRIPTION
Reorganize tests to take more advantage of pytest fixtures. Modularize tests.

Should address #118, #119, #120, #121, #122, #123, #124, #125 #126 #127