### PR TITLE
Repair dpss grid

### DIFF
--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -2153,8 +2153,7 @@ def dpss_operator(x, filter_centers, filter_half_widths, cache=None, eigenval_cu
     if not opkey in cache:
         # try placing x on a uniform grid.
         x, _, _, inserted = place_data_on_uniform_grid(x, np.zeros(len(x)), np.ones(len(x)))
-        #check that xs are equally spaced.
-        if not np.all(np.isclose(np.diff(x), np.mean(np.diff(x)), rtol=0., atol=np.abs(xtol * np.mean(np.diff(x))))):
+        if not np.allclose(np.diff(x), np.median(np.diff(x)), rtol=0., atol=np.abs(xtol * np.median(np.diff(x)))):
             #for now, don't support DPSS iterpolation unless x is equally spaced.
             #In principal, I should be able to compute off-grid DPSS points using
             #the fourier integral of the DPSWF
@@ -2192,8 +2191,12 @@ def dpss_operator(x, filter_centers, filter_half_widths, cache=None, eigenval_cu
         for fc, fw, nt in zip(filter_centers,filter_half_widths, nterms):
             amat.append(np.exp(2j * np.pi * (yg[:,:nt]-xc) * fc ) * windows.dpss(nf, nf * df * fw, nt).T )
         # only select inserted frequencies in A-matrix.
-        amat = np.hstack(amat)[~inserted, :]
-        cache[opkey] = ( np.hstack(amat), nterms )
+        if len(amat) > 1:
+            amat = np.hstack(amat)
+        else:
+            amat = amat[0]
+        amat = amat[~inserted, :]
+        cache[opkey] = (amat, nterms)
     return cache[opkey]
 
 

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -1663,6 +1663,9 @@ def _fit_basis_1d(x, y, w, filter_centers, filter_half_widths,
         try:
             res = lsq_linear(a, w * y)
             cn_out = res.x
+        # np.linalg.LinAlgError catches "SVD did not converge."
+        # which can happen if the solution is under-constrained.
+        # also handle nans and infs in the data here too.
         except (np.linalg.LinAlgError, ValueError, TypeError) as err:
             warn(f"{err} -- recording skipped integration in info and setting to zero.")
             cn_out = 0.0

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -1663,7 +1663,7 @@ def _fit_basis_1d(x, y, w, filter_centers, filter_half_widths,
         try:
             res = lsq_linear(a, w * y)
             cn_out = res.x
-        except (np.linalg.LinAlgError, ValueError) as err:
+        except (np.linalg.LinAlgError, ValueError, TypeError) as err:
             warn(f"{err} -- recording skipped integration in info and setting to zero.")
             cn_out = 0.0
             info['skipped'] = True

--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -2151,6 +2151,8 @@ def dpss_operator(x, filter_centers, filter_half_widths, cache=None, eigenval_cu
                                  w=None, hash_decimal=hash_decimal,
                                  label='dpss_operator', crit_val=tuple(crit_provided_value[0]))
     if not opkey in cache:
+        # try placing x on a uniform grid.
+        x, _, _, inserted = place_data_on_uniform_grid(x, np.zeros(len(x)), np.ones(len(x)))
         #check that xs are equally spaced.
         if not np.all(np.isclose(np.diff(x), np.mean(np.diff(x)), rtol=0., atol=np.abs(xtol * np.mean(np.diff(x))))):
             #for now, don't support DPSS iterpolation unless x is equally spaced.
@@ -2189,6 +2191,8 @@ def dpss_operator(x, filter_centers, filter_half_widths, cache=None, eigenval_cu
         amat = []
         for fc, fw, nt in zip(filter_centers,filter_half_widths, nterms):
             amat.append(np.exp(2j * np.pi * (yg[:,:nt]-xc) * fc ) * windows.dpss(nf, nf * df * fw, nt).T )
+        # only select inserted frequencies in A-matrix.
+        amat = np.hstack(amat)[~inserted, :]
         cache[opkey] = ( np.hstack(amat), nterms )
     return cache[opkey]
 

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -231,9 +231,9 @@ def test_dpss_operator():
     NF = 100
     DF = 100e3
     freqs = np.arange(-NF/2, NF/2)*DF + 150e6
-    freqs_bad = freqs[[0, 12, 14, 18, 22]]
+    freqs_bad = np.array([1.100912386458, 1.22317, 2.12341260, 3.234632462, 5.32348356887])
     pytest.raises(ValueError, dspec.dpss_operator, x=freqs_bad, filter_centers=[0.], filter_half_widths=[1e-6], nterms=[5])
-    pytest.raises(ValueError, dspec.dpss_operator, x = freqs , filter_centers=[0.], filter_half_widths=[1e-6], nterms=[5], avg_suppression=[1e-12])
+    pytest.raises(ValueError, dspec.dpss_operator, x=freqs , filter_centers=[0.], filter_half_widths=[1e-6], nterms=[5], avg_suppression=[1e-12])
     #now calculate DPSS operator matrices using different cutoff criteria. The columns
     #should be the same up to the minimum number of columns of the three techniques.
     amat1, ncol1 = dspec.dpss_operator(freqs, [0.], [100e-9], eigenval_cutoff=[1e-9])

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -1147,13 +1147,13 @@ def test_fit_basis_1d_with_missing_channels():
     wgts[17] = 0
     dw = data*wgts
     # dft fitting options
-    dft_opts={'fundamental_period':200.}
+    dpss_opts={'eigenval_cutoff':[1e-12]}
     # now remove ten random channels.
     to_remove = [2, 10, 11, 23, 54, 71, 87, 88, 89, 97]
     to_keep = np.array([i for i in range(len(fs)) if i not in to_remove])
 
-    mod5, resid5, info5 = dspec._fit_basis_1d(fs[to_keep], dw[to_keep], wgts[to_keep], [0.], [5./50.], basis_options=dft_opts,
-                                    method='leastsq', basis='dft')
+    mod5, resid5, info5 = dspec._fit_basis_1d(fs[to_keep], dw[to_keep], wgts[to_keep], [0.], [5./50.], basis_options=dpss_opts,
+                                    method='leastsq', basis='dpss')
 
     dwt = copy.deepcopy(dw)
     wgtst = copy.deepcopy(wgts)
@@ -1161,8 +1161,8 @@ def test_fit_basis_1d_with_missing_channels():
     dwt[to_remove] = 0.0
     wgtst[to_remove] = 0.0
 
-    mod6, resid6, info6 = dspec._fit_basis_1d(fs, dwt, wgtst, [0.], [5./50.], basis_options=dft_opts,
-                                    method='leastsq', basis='dft')
+    mod6, resid6, info6 = dspec._fit_basis_1d(fs, dwt, wgtst, [0.], [5./50.], basis_options=dpss_opts,
+                                    method='leastsq', basis='dpss')
 
     assert np.allclose(mod5, mod6[to_keep])
     assert np.allclose(resid5, resid6[to_keep])

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -1147,12 +1147,12 @@ def test_fit_basis_1d_with_missing_channels():
     wgts[17] = 0
     dw = data*wgts
     # dft fitting options
-    dpss_opts={'eigenval_cutoff':[1e-12]}
+    dpss_opts={'eigenval_cutoff':[1e-12, 1e-12]}
     # now remove ten random channels.
     to_remove = [2, 10, 11, 23, 54, 71, 87, 88, 89, 97]
     to_keep = np.array([i for i in range(len(fs)) if i not in to_remove])
 
-    mod5, resid5, info5 = dspec._fit_basis_1d(fs[to_keep], dw[to_keep], wgts[to_keep], [0.], [5./50.], basis_options=dpss_opts,
+    mod5, resid5, info5 = dspec._fit_basis_1d(fs[to_keep], dw[to_keep], wgts[to_keep], [0., 10/50.], [5./50., 1./50.], basis_options=dpss_opts,
                                     method='leastsq', basis='dpss')
 
     dwt = copy.deepcopy(dw)
@@ -1161,7 +1161,7 @@ def test_fit_basis_1d_with_missing_channels():
     dwt[to_remove] = 0.0
     wgtst[to_remove] = 0.0
 
-    mod6, resid6, info6 = dspec._fit_basis_1d(fs, dwt, wgtst, [0.], [5./50.], basis_options=dpss_opts,
+    mod6, resid6, info6 = dspec._fit_basis_1d(fs, dwt, wgtst, [0., 10/50.], [5./50., 1./50.], basis_options=dpss_opts,
                                     method='leastsq', basis='dpss')
 
     assert np.allclose(mod5, mod6[to_keep])


### PR DESCRIPTION
Incorporate `place_data_on_uniform_grid()` into `dpss_operator` so that we can generate DPSS fitting operators on data that is on a grid but the grid has missing values (for example, if we want to jointly fit multiple disjoint spectral windows)