### PR TITLE
Bugfix, wrong tolerance applied when placing data on uniform grid

### DIFF
--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -162,17 +162,17 @@ def place_data_on_uniform_grid(x, data, weights, xtol=1e-3):
               boolean array indicating which x-values were inserted.
     """
     xdiff = np.diff(x)
-    dx = np.abs(np.diff(x)).min() * np.sign(np.diff(x)[0])
+    dx = np.median(np.abs(np.diff(x))) * np.sign(np.diff(x)[0])
     # first, check whether x, y, w already on a grid.
     # if they are, just return them.
-    if np.allclose(xdiff, dx, rtol=0, atol=dx * xtol):
+    if np.allclose(xdiff, dx, rtol=0, atol=np.abs(dx * xtol)):
         xout = x
         dout = data
         wout = weights
         inserted = np.zeros(len(x), dtype=bool)
         return xout, dout, wout, inserted
     # next, check that the array is not on a grid and if it isn't, return x, y, w
-    if not np.allclose(xdiff / dx, np.round(xdiff / dx), rtol=0.0, atol=np.abs(xtol * dx)):
+    if not np.allclose(xdiff / dx, np.round(xdiff / dx), rtol=0.0, atol=xtol):
         xout = x
         dout = data
         wout = weights


### PR DESCRIPTION
Currently, an absolute tolerance is being used to determine the tolerance between two numbers that have already been converted to relative units. The relative tolerance should be used instead. 

Also fix potential sign issue by converting xtol * dx ->  np.abs(xtol * dx) and use median of data spacing rather then min to determine grid size.