### PR TITLE
Improve the speed of the sinc matrix eigenvalue calculation by using dpss_operator

### DIFF
--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -2185,10 +2185,8 @@ def dpss_operator(x, filter_centers, filter_half_widths, cache=None, eigenval_cu
         if nterms is None:
             nterms = []
             for fn,fw in enumerate(filter_half_widths):
-                dpss_vectors = windows.dpss(nf, nf * df * fw, nf)
+                dpss_vectors, eigvals = windows.dpss(nf, nf * df * fw, nf, return_ratios=True)
                 if not eigenval_cutoff is None:
-                    smat = np.sinc(2 * fw * (xg-yg)) * 2 * df * fw
-                    eigvals = np.sum((smat @ dpss_vectors.T) * dpss_vectors.T, axis=0)
                     nterms.append(np.max(np.where(eigvals>=eigenval_cutoff[fn])))
                 if not edge_suppression is None:
                     z0=fw * df

--- a/uvtools/tests/test_plot.py
+++ b/uvtools/tests/test_plot.py
@@ -9,6 +9,8 @@ from astropy import units
 from pyuvdata import UVData
 from ..data import DATA_PATH
 import os
+if os.environ.get('DISPLAY', '') == '':
+    matplotlib.use('Agg')
 
 def axes_contains(ax, obj_list):
     """Check that a matplotlib.Axes instance contains certain elements.


### PR DESCRIPTION
When calculating eigenvalues in `uvtools.dspec.dpss_operator` to determine the number of DPSS vectors used when filtering data, we currently are recalculating the eigenvalues from the sinc matrix instead of using the values computed by `scipy.signal.windows.dpss`. This fix should speed up the runtime of this function without changing the values of the eigenvalues produced.