### PR TITLE
Add pypy ci

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -1,0 +1,49 @@
+name: Publish Python distributions to PyPI and TestPyPI
+
+on: [push, pull_request]
+
+jobs:
+  build-n-publish:
+    name: Build and publish to PyPI and TestPyPI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        # Adding -l {0} helps ensure conda can be found properly.
+        shell: bash -l {0}
+    env:
+      ENV_NAME: publish
+      PYTHON: 3.8
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2.0.0
+        with:
+          auto-update-conda: true
+          miniconda-version: "latest"
+          python-version: ${{ env.PYTHON }}
+          environment-file: ci/${{ env.ENV_NAME }}.yaml
+          activate-environment: ${{ env.ENV_NAME }}
+
+      - name: Conda Info
+        run: |
+          conda info -a
+          conda list
+          PYVER=`python -c "import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
+          if [[ $PYVER != ${{ env.PYTHON }} ]]; then
+            exit 1;
+          fi
+
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -m pep517.build --source --out-dir dist/ .
+
+
+      - name: Publish to PyPI
+        if: startsWith(github.event.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -1,46 +1,26 @@
-name: Publish Python distributions to PyPI and TestPyPI
+name: Publish Python distributions to PyPI
 
 on: [push, pull_request]
 
 jobs:
   build-n-publish:
-    name: Build and publish to PyPI and TestPyPI
+    name: Build and publish to PyPI
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        # Adding -l {0} helps ensure conda can be found properly.
-        shell: bash -l {0}
-    env:
-      ENV_NAME: publish
-      PYTHON: 3.8
     steps:
       - uses: actions/checkout@master
         with:
           fetch-depth: 0
 
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.0.0
+      - uses: actions/setup-python@v4
         with:
-          auto-update-conda: true
-          miniconda-version: "latest"
-          python-version: ${{ env.PYTHON }}
-          environment-file: ci/${{ env.ENV_NAME }}.yaml
-          activate-environment: ${{ env.ENV_NAME }}
+          python-version: "3.10"
 
-      - name: Conda Info
-        run: |
-          conda info -a
-          conda list
-          PYVER=`python -c "import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
-          if [[ $PYVER != ${{ env.PYTHON }} ]]; then
-            exit 1;
-          fi
-
+      - name: Install Build Tools
+        run: pip install build
 
       - name: Build a binary wheel and a source tarball
         run: |
-          python -m pep517.build --source --out-dir dist/ .
-
+          python -m build .
 
       - name: Publish to PyPI
         if: startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -5,22 +5,24 @@
 Tools useful for the handling, visualization, and analysis of interferometric data.
 
 ## Installation
-Preferred method is `pip install .` (or `pip install git+https://github.com/HERA-Team/uvtools`).
-This should install all dependencies.
+Best method is to install from [![pypi](https://pypi.org/project/uvtools)] with `pip install uvtools`
+
+
+Developer install from the github repo by cloning/pulling and then in ./uvtools/ run `pip install .`
 
 If you use `conda` (preferred), then you may wish to install the following packages
 manually before installing `uvtools` (if you don't have them already)::
 
     $ conda install -c conda-forge numpy scipy "aipy>=3.0rc2"
-    
-If you are developing `uvtools`, you will also require `nose` and `pyuvdata` to run 
+
+If you are developing `uvtools`, you will also require `nose` and `pyuvdata` to run
 tests. All of these packages can be installed with the following commands::
 
     $ conda create -n uvtools python=3
     $ conda activate uvtools
     $ conda env update -n uvtools -f environment.yml
-    $ pip install -e . 
-    
+    $ pip install -e .
+
 To test the package, execute the following command::
 
-    $ nosetests uvtools/tests/test_dspec.py uvtools/tests/test_utils.py 
+    $ nosetests uvtools/tests/test_dspec.py uvtools/tests/test_utils.py


### PR DESCRIPTION
This repo is now installable from pipy. This is the preferred installation method for normal users and testing. This PR also adds a github action which causes tagged versions to be built and uploaded to pipy.
