### PR TITLE
fix: remove deprecated numpy types

### DIFF
--- a/uvtools/dspec.py
+++ b/uvtools/dspec.py
@@ -81,7 +81,7 @@ def wedge_width(bl_len, sdf, nchan, standoff=0., horizon=1.):
     Returns:
         uthresh, lthresh: bin indices for filtered bins started at uthresh (which is filtered)
             and ending at lthresh (which is a negative integer and also not filtered)
-            Designed for area = np.ones(nchan, dtype=np.int); area[uthresh:lthresh] = 0
+            Designed for area = np.ones(nchan, dtype=int); area[uthresh:lthresh] = 0
     '''
     bl_dly = horizon * bl_len + standoff
     return calc_width(bl_dly, sdf, nchan)
@@ -183,7 +183,7 @@ def place_data_on_uniform_grid(x, data, weights, xtol=1e-3):
     grid_size =int(np.round((x[-1] - x[0]) / dx)) + 1
     xout = np.linspace(x[0], x[-1], grid_size)
     dout = np.zeros(grid_size, dtype=np.complex128)
-    wout = np.zeros(grid_size, dtype=np.float)
+    wout = np.zeros(grid_size, dtype=float)
     inserted = np.ones(grid_size, dtype=bool)
     # fill in original data and weights.
     for x_index, xt in enumerate(x):
@@ -243,7 +243,7 @@ def calc_width(filter_size, real_delta, nsamples):
     Returns:
         uthresh, lthresh: bin indices for filtered bins started at uthresh (which is filtered)
             and ending at lthresh (which is a negative integer and also not filtered).
-            Designed for area = np.ones(nsamples, dtype=np.int); area[uthresh:lthresh] = 0
+            Designed for area = np.ones(nsamples, dtype=int); area[uthresh:lthresh] = 0
     '''
     if isinstance(filter_size, (list, tuple, np.ndarray)):
         _, l = calc_width(np.abs(filter_size[0]), real_delta, nsamples)
@@ -776,7 +776,7 @@ def dayenu_filter(x, data, wgts, filter_dimensions, filter_centers, filter_half_
     if not isinstance(x, (np.ndarray,list, tuple)):
         raise ValueError("x must be a numpy array, list, or tuple")
     # Check that inputs are tiples or lists
-    if not isinstance(filter_dimensions, (list,tuple,int, np.int)):
+    if not isinstance(filter_dimensions, (list,tuple,int)):
         raise ValueError("filter_dimensions must be a list or tuple")
     # if filter_dimensions are supplied as a single integer, convert to list (core code assumes lists).
     if isinstance(filter_dimensions, int):
@@ -786,7 +786,7 @@ def dayenu_filter(x, data, wgts, filter_dimensions, filter_centers, filter_half_
         raise ValueError("length of filter_dimensions cannot exceed 2")
     # make sure filter_dimensions are 0 or 1.
     for dim in filter_dimensions:
-        if not dim in [0, 1] or not isinstance(dim, (int, np.int)):
+        if not dim in [0, 1] or not isinstance(dim, int):
             raise ValueError("filter dimension must be integer 0, or 1")
 
     # convert filter dimensions to a list of integers (incase the dimensions were supplied as floats)
@@ -810,7 +810,7 @@ def dayenu_filter(x, data, wgts, filter_dimensions, filter_centers, filter_half_
         # If any of these inputs is a float or numpy array, convert to a list.
         if isinstance(avar, np.ndarray):
             check_vars[anum] = list(avar)
-        elif isinstance(avar, np.float):
+        elif isinstance(avar, float):
             check_vars[anum] = [avar]
 
     filter_centers,filter_half_widths,filter_factors = check_vars
@@ -1126,9 +1126,9 @@ def vis_filter(data, wgts, max_frate=None, dt=None, bl_len=None, sdf=None, stand
             fc = 0.
             fw = max_frate
         # 2D clean
-        if isinstance(edgecut_hi, (int, np.int)):
+        if isinstance(edgecut_hi, int):
             edgecut_hi = (edgecut_hi, edgecut_hi)
-        if isinstance(edgecut_low, (int, np.int)):
+        if isinstance(edgecut_low, int):
             edgecut_low = (edgecut_low, edgecut_low)
         if isinstance(window, str):
             window = (window, window)
@@ -1171,7 +1171,7 @@ def gen_window(window, N, alpha=0.5, edgecut_low=0, edgecut_hi=0, normalization=
         if normalization not in ["mean", "rms"]:
             raise ValueError("normalization must be one of ['rms', 'mean']")
     # parse multiple input window or special windows
-    w = np.zeros(N, dtype=np.float)
+    w = np.zeros(N, dtype=float)
     Ncut = edgecut_low + edgecut_hi
     if Ncut >= N:
         raise ValueError("Ncut >= N for edgecut_low {} and edgecut_hi {}".format(edgecut_low, edgecut_hi))
@@ -1520,9 +1520,9 @@ def delay_filter_leastsq(data, flags, sigma, nmax, add_noise=False,
 
     nmodes = nmax - nmin + 1
     # Array to store in-painted data
-    inp_data = np.zeros(data.shape, dtype=np.complex)
-    cn_array = np.zeros((data.shape[0], nmodes), dtype=np.complex)
-    mdl_array = np.zeros(data.shape, dtype=np.complex)
+    inp_data = np.zeros(data.shape, dtype=complex)
+    cn_array = np.zeros((data.shape[0], nmodes), dtype=complex)
+    mdl_array = np.zeros(data.shape, dtype=complex)
 
     # Loop over array
     cn_out = None
@@ -1951,7 +1951,7 @@ def _fit_basis_2d(x, data, wgts, filter_centers, filter_half_widths,
                                - 'basis_options': the basis options used for dpss/dft mode. See dft_operator and dpss_operator for
                                                   more details.
     """
-    if isinstance(filter_dims, (int, np.integer)):
+    if isinstance(filter_dims, int):
         filter_dims = [filter_dims]
     if cache is None:
         cache={}
@@ -2391,11 +2391,11 @@ def dayenu_mat_inv(x, filter_centers, filter_half_widths,
     """
     if cache is None:
         cache = {}
-    if isinstance(filter_factors,(float,int, np.int, np.float)):
+    if isinstance(filter_factors,(float,int)):
         filter_factors = [filter_factors]
-    if isinstance(filter_centers, (float, int, np.int, np.float)):
+    if isinstance(filter_centers, (float, int)):
         filter_centers = [filter_centers]
-    if isinstance(filter_half_widths, (float, int, np.int, np.float)):
+    if isinstance(filter_half_widths, (float, int)):
         filter_half_widths = [filter_half_widths]
 
     nchan = len(x)

--- a/uvtools/tests/test_dspec.py
+++ b/uvtools/tests/test_dspec.py
@@ -39,8 +39,8 @@ def test_delay_filter_dims():
 def test_delay_filter_1D():
     NCHAN = 128
     TOL = 1e-6
-    data = np.ones(NCHAN, dtype=np.complex)
-    wgts = .5*np.ones(NCHAN, dtype=np.complex)
+    data = np.ones(NCHAN, dtype=complex)
+    wgts = .5*np.ones(NCHAN, dtype=complex)
     dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
     np.testing.assert_allclose(data, dmdl, atol=NCHAN*TOL)
     np.testing.assert_allclose(dres, np.zeros_like(dres), atol=NCHAN*TOL)
@@ -67,8 +67,8 @@ def test_delay_filter_2D():
     NCHAN = 128
     NTIMES = 10
     TOL = 1e-6
-    data = np.ones((NTIMES, NCHAN), dtype=np.complex)
-    wgts = np.ones((NTIMES, NCHAN), dtype=np.complex)
+    data = np.ones((NTIMES, NCHAN), dtype=complex)
+    wgts = np.ones((NTIMES, NCHAN), dtype=complex)
     dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL)
     np.testing.assert_allclose(data, dmdl, atol=NCHAN*TOL)
     np.testing.assert_allclose(dres, np.zeros_like(dres), atol=NCHAN*TOL)
@@ -106,7 +106,7 @@ def test_delay_filter_leastsq():
     NCHAN = 128
     NTIMES = 10
     TOL = 1e-7
-    data = np.ones((NTIMES, NCHAN), dtype=np.complex)
+    data = np.ones((NTIMES, NCHAN), dtype=complex)
     flags = np.zeros((NTIMES, NCHAN), dtype=np.bool)
     sigma = 0.1 # Noise level (not important here)
 
@@ -162,8 +162,8 @@ def test_skip_wgt():
     NCHAN = 128
     NTIMES = 10
     TOL = 1e-6
-    data = np.ones((NTIMES, NCHAN), dtype=np.complex)
-    wgts = np.ones((NTIMES, NCHAN), dtype=np.complex)
+    data = np.ones((NTIMES, NCHAN), dtype=complex)
+    wgts = np.ones((NTIMES, NCHAN), dtype=complex)
     wgts[0, 0:-4] = 0
     dmdl, dres, info = dspec.delay_filter(data, wgts, 0., .1/NCHAN, tol=TOL, skip_wgt=.1)
     np.testing.assert_allclose(data[1:,:], dmdl[1:,:], atol=NCHAN*TOL)
@@ -524,7 +524,7 @@ def test_vis_filter():
     dfr, ddly = frs[1] - frs[0], dlys[1] - dlys[0]
     d = 200 * np.exp(-2j*np.pi*times[:, None]*(frs[2]+dfr/4) - 2j*np.pi*freqs[None, :]*(dlys[2]+ddly/4)/1e9)
     d += 50 * np.exp(-2j*np.pi*times[:, None]*(frs[20]) - 2j*np.pi*freqs[None, :]*(dlys[20])/1e9)
-    d += 10 * ((np.random.normal(0, 1, uvd.Nfreqs * uvd.Ntimes).astype(np.complex) \
+    d += 10 * ((np.random.normal(0, 1, uvd.Nfreqs * uvd.Ntimes).astype(complex) \
          + 1j * np.random.normal(0, 1, uvd.Nfreqs * uvd.Ntimes)).reshape(uvd.Ntimes, uvd.Nfreqs))
 
     def get_snr(clean, fftax=1, avgax=0, modes=[2, 20]):
@@ -542,7 +542,7 @@ def test_vis_filter():
     f[:, 20:22] = True
     d[20, :] += 1e3
     f[20, :] = True
-    w = (~f).astype(np.float)
+    w = (~f).astype(float)
     bl_len = 70.0 / 2.99e8
 
     # try passing skip_wgt
@@ -708,7 +708,7 @@ def test_fourier_filter():
     f[:, 20:22] = True
     d[20, :] += 1e3
     f[20, :] = True
-    w = (~f).astype(np.float)
+    w = (~f).astype(float)
     bl_len = dlys[nf//2+4]
     fr_len = frs[ntimes//2+4]
     # dpss filtering
@@ -946,14 +946,14 @@ def test_vis_clean():
     dfr, ddly = frs[1] - frs[0], dlys[1] - dlys[0]
     d = 200 * np.exp(-2j*np.pi*times[:, None]*(frs[2]+dfr/4) - 2j*np.pi*freqs[None, :]*(dlys[2]+ddly/4)/1e9)
     d += 50 * np.exp(-2j*np.pi*times[:, None]*(frs[20]) - 2j*np.pi*freqs[None, :]*(dlys[20])/1e9)
-    d += 10 * ((np.random.normal(0, 1, uvd.Nfreqs * uvd.Ntimes).astype(np.complex) \
+    d += 10 * ((np.random.normal(0, 1, uvd.Nfreqs * uvd.Ntimes).astype(complex) \
          + 1j * np.random.normal(0, 1, uvd.Nfreqs * uvd.Ntimes)).reshape(uvd.Ntimes, uvd.Nfreqs))
     f = np.zeros_like(d, dtype=np.bool)
     d[:, 20:22] += 1e3
     f[:, 20:22] = True
     d[20, :] += 1e3
     f[20, :] = True
-    w = (~f).astype(np.float)
+    w = (~f).astype(float)
     bl_len = 70.0 / 2.99e8
     # here is a fourier filter implementation of clean
     mdl1, res1, info1 = dspec.fourier_filter(freqs, d, w, [0.], [bl_len],

--- a/uvtools/tests/test_plot.py
+++ b/uvtools/tests/test_plot.py
@@ -248,7 +248,7 @@ from ..data import DATA_PATH
 #            )
 #
 #        with pytest.raises(ValueError):
-#            plot.fourier_transform_waterfalls(data=np.ones((3,5,2), dtype=np.complex))
+#            plot.fourier_transform_waterfalls(data=np.ones((3,5,2), dtype=complex))
 #
 #        with pytest.raises(ValueError):
 #            plot.fourier_transform_waterfalls(data=data, freqs=freqs)
@@ -260,7 +260,7 @@ from ..data import DATA_PATH
 #            plot.fourier_transform_waterfalls(data=uvd)
 #
 #        with pytest.raises(TypeError):
-#            plot.fourier_transform_waterfalls(data=np.ones((15,20), dtype=np.float))
+#            plot.fourier_transform_waterfalls(data=np.ones((15,20), dtype=float))
 #        self.tearDown()
 
 #class TestDiffPlotters():

--- a/uvtools/tests/test_utils.py
+++ b/uvtools/tests/test_utils.py
@@ -51,7 +51,7 @@ def test_search_data():
     # flatten
     dfs, dps = utils.search_data(templates, pols, flatten=True)
     assert len(dfs) == 4
-    assert isinstance(dfs[0], (str, np.str))
+    assert isinstance(dfs[0], str)
 
     for f in allfiles:
         if os.path.exists(f):

--- a/uvtools/utils.py
+++ b/uvtools/utils.py
@@ -43,9 +43,9 @@ def search_data(templates, pols, matched_pols=False, reverse_nesting=False, flat
         List of polarizations for each file in datafile
     """
     # type check
-    if isinstance(templates, (str, np.str)):
+    if isinstance(templates, str):
         templates = [templates]
-    if isinstance(pols, (str, np.str, np.integer, int)):
+    if isinstance(pols, (str, int)):
         pols = [pols]
     # search for datafiles
     datafiles = []


### PR DESCRIPTION
Removes all the `np.int`, `np.float`, `np.complex` and `np.str`