### PR TITLE
ci: add config files for auto-labelling and release drafting

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -43,9 +43,6 @@
 - name: performance
   description: Performance
   color: "016175"
-- name: python
-  description: Pull requests that update Python code
-  color: 2b67c6
 - name: question
   description: Further information is requested
   color: d876e3

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,66 @@
+---
+# Labels names are important as they are used by Release Drafter to decide
+# regarding where to record them in changelog or if to skip them.
+#
+# The repository labels will be automatically configured using this file and
+# the GitHub Action https://github.com/marketplace/actions/github-labeler.
+- name: breaking
+  description: Breaking Changes
+  color: bfd4f2
+- name: bug
+  description: Something isn't working
+  color: d73a4a
+- name: build
+  description: Build System and Dependencies
+  color: bfdadc
+- name: ci
+  description: Continuous Integration
+  color: 4a97d6
+- name: dependencies
+  description: Pull requests that update a dependency file
+  color: 0366d6
+- name: documentation
+  description: Improvements or additions to documentation
+  color: 0075ca
+- name: duplicate
+  description: This issue or pull request already exists
+  color: cfd3d7
+- name: enhancement
+  description: New feature or request
+  color: a2eeef
+- name: github_actions
+  description: Pull requests that update Github_actions code
+  color: "000000"
+- name: good first issue
+  description: Good for newcomers
+  color: 7057ff
+- name: help wanted
+  description: Extra attention is needed
+  color: 008672
+- name: invalid
+  description: This doesn't seem right
+  color: e4e669
+- name: performance
+  description: Performance
+  color: "016175"
+- name: python
+  description: Pull requests that update Python code
+  color: 2b67c6
+- name: question
+  description: Further information is requested
+  color: d876e3
+- name: refactoring
+  description: Refactoring
+  color: ef67c4
+- name: removal
+  description: Removals and Deprecations
+  color: 9ae7ea
+- name: style
+  description: Style
+  color: c120e5
+- name: testing
+  description: Testing
+  color: b1fc6f
+- name: wontfix
+  description: This will not be worked on
+  color: ffffff

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,68 @@
+# See https://github.com/marketplace/actions/release-drafter for configuration
+categories:
+  - title: ":boom: Breaking Changes"
+    label: "breaking"
+  - title: ":rocket: Features"
+    label: "enhancement"
+  - title: ":fire: Removals and Deprecations"
+    label: "removal"
+  - title: ":beetle: Fixes"
+    label: "bug"
+  - title: ":racehorse: Performance"
+    label: "performance"
+  - title: ":rotating_light: Testing"
+    label: "testing"
+  - title: ":construction_worker: Continuous Integration"
+    label: "ci"
+  - title: ":books: Documentation"
+    label: "documentation"
+  - title: ":hammer: Refactoring"
+    label: "refactoring"
+  - title: ":lipstick: Style"
+    label: "style"
+  - title: ":package: Dependencies"
+    labels:
+      - "dependencies"
+      - "build"
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+autolabeler:
+  - label: 'documentation'
+    files:
+      - '*.md'
+    branch:
+      - '/.*docs{0,1}.*/'
+  - label: 'bug'
+    branch:
+      - '/fix.*/'
+    title:
+      - '/fix/i'
+  - label: 'enhancement'
+    branch:
+      - '/feature.*|add-.+/'
+    title:
+      - '/feat:.+|feature:.+/i'
+    body:
+      - '/JIRA-[0-9]{1,4}/'
+  - label: "removal"
+    title:
+      - "/remove .*/i"
+  - label: "performance"
+    title:
+      - "/.* performance .*/i"
+  - label: "ci"
+    files:
+      - '.github/*'
+      - '.pre-commit-config.yaml'
+      - '.coveragrc'
+  - label: "style"
+    files:
+      - ".flake8"
+  - label: "refactoring"
+    title:
+      - "/.* refactor.*/i"
+
+template: |
+  ## Changes
+
+  $CHANGES


### PR DESCRIPTION
This is the first step in adding better packaging/release mechanisms to uvtools (see #152). This has to be merged to main for some of the workflows in that PR to work. After everything is in, releasing should follow the new way implemented in https://github.com/hera-team/aipy. In brief:

* On each push/PR, we automatically create (or update) a Draft Github Release with the unreleased changes. This serves as an automatic online changelog, rather than spotty manual updating of a text changelog. This is just a DRAFT.
* Also on each push, we check that the distribution builds and that `twine check` runs without error (but we don't release to PyPI). 
* The Draft Release has an automatically *suggested* version, based on labels applied to all un-released merged PRs. These labels are semi-automatically applied based on rules in the configuration defined in this PR (in the release-drafter yaml). Of course, manual labels can also be applied. 
* When a new release is desired, a maintainer simply has to go to the newest draft release, which has the suggested version already. They can modify this version if they like, but mostly everything should already be in-tact. They just have to hit the "Publish" button. This sets off another workflow which uploads the package to PyPI with the latest tag (which corresponds to the release). 

I think this is an easy and very visual way to do releases. I noticed that uvtools in particular has a poorly maintained changelog, so some of this automation is probably very useful.
